### PR TITLE
make hash consistent by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Filter identifiers are unique hashes, dependant on the following:
 
 * filters in their [canonicalized form](https://en.wikipedia.org/wiki/Canonicalization)
 * the index and collection parameters (see [above](#index-and-collection-parameters))
-* a random seed (see the engine's [constructor](#constructor) documentation)
+* a seed (see the engine's [constructor](#constructor) documentation)
 
 This means that:
 
@@ -284,8 +284,8 @@ Instantiates a new Koncorde engine.
 
 | Name | Type | Default |Description                      |
 |------|------|---------|---------------------------------|
-|`maxConditions`| `Number` | `8` | The maximum number of conditions a filter can hold. It is not advised to use a value greater than `15` without testing filter registration and matching performances |
-|`seed`|`Buffer`| Randomly generated seed | 32 bytes buffer containing a fixed random seed |
+|`maxMinTerms`| `Number` | `256` | The maximum number of conditions a filter can hold after being canonized in its [CDNF](https://en.wikipedia.org/wiki/Canonical_normal_form) form. It is advised to test performance and memory consumption impacts before increasing this value. If set to 0, no limit is applied.
+|`seed`|`Buffer`| fixed | 32 bytes buffer containing a fixed random seed. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Instantiates a new Koncorde engine.
 
 | Name | Type | Default |Description                      |
 |------|------|---------|---------------------------------|
-|`maxMinTerms`| `Number` | `256` | The maximum number of conditions a filter can hold after being canonized in its [CDNF](https://en.wikipedia.org/wiki/Canonical_normal_form) form. It is advised to test performance and memory consumption impacts before increasing this value. If set to 0, no limit is applied.
+|`maxMinTerms`| `Number` | `256` | The maximum number of conditions a filter can hold after being canonicalized in its [CDNF](https://en.wikipedia.org/wiki/Canonical_normal_form) form. It is advised to test performance and memory consumption impacts before increasing this value. If set to 0, no limit is applied.
 |`seed`|`Buffer`| fixed | 32 bytes buffer containing a fixed random seed. 
 
 ---

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,10 +37,17 @@ class Koncorde {
    * @param {Object} config
    */
   constructor(config) {
-    this.config = config || {};
-
-    if (typeof this.config !== 'object' || Array.isArray(this.config)) {
+    if (config && (typeof config !== 'object' || Array.isArray(config))) {
       throw new Error('Invalid argument: expected an object');
+    }
+
+    this.config = Object.assign({
+      seed: Buffer.from('o%dWl&F@%*Sr$7i18x3@@&uXQOC$X8az'),
+      maxMinTerms: 256
+    }, config || {});
+
+    if (!(this.config.seed instanceof Buffer) || this.config.seed.length !== 32) {
+      throw new Error('Invalid seed: expected a 32 bytes long Buffer');
     }
 
     this.transformer = new Transformer(this.config);

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -162,71 +162,30 @@ class Storage {
   }
 
   /**
-   * Decomposes and stores a normalized filter
-   *
-   * @param {string} index
-   * @param {string} collection
-   * @param {Array} filters
-   * @param {String} [filterId] Optional: may be computed beforehand with getFilterId
-   * @return {object}
+   * Returns the filter id calculated from its components
+   * @param  {String} index      Data index
+   * @param  {String} collection Data collection
+   * @param  {Object} filters    Normalized filters
+   * @return {String}            Filter unique ID
    */
-  store (index, collection, filters, filterId = null) {
-    const
-      result = this._addFilter(index, collection, filters, filterId),
-      response = {
-        id: result.id,
-        diff: {
-          index,
-          collection,
-          filters
-        }
-      };
+  getFilterId (index, collection, filters) {
+    return this.hash({index, collection, filters});
+  }
 
-    if (!result.created) {
-      return response;
+  hash (input) {
+    let inString;
+
+    switch (typeof input) {
+      case 'string':
+      case 'number':
+      case 'boolean':
+        inString = input;
+        break;
+      default:
+        inString = stringify(input);
     }
 
-    this._addFiltersIndex(index, collection, result.id);
-
-    let i; // NOSONAR
-
-    for(i = 0; i < filters.length; i++) {
-      const 
-        sf = filters[i],
-        sfResult = this._addSubfilter(this.filters[result.id], sf);
-
-      if (sfResult.created) {
-        const
-          subfilter = this.subfilters[index][collection][sfResult.id],
-          addedConditions = this._addConditions(subfilter, index, collection, sf);
-
-        this._addTestTables(subfilter, index, collection);
-        Storage.addIndexCollectionToObject(this.foPairs, index, collection);
-
-        let j; // NOSONAR
-        for(j = 0; j < addedConditions.length; j++) {
-          const cond = addedConditions[j];
-
-          if (!this.foPairs[index][collection][cond.keyword]) {
-            this.foPairs[index][collection][cond.keyword] = new FieldOperand();
-          }
-
-          this.storeOperand[cond.keyword](this.foPairs[index][collection][cond.keyword], subfilter, cond);
-        }
-      }
-    }
-
-    // ref https://github.com/kuzzleio/kuzzle/issues/740
-    const filter = this.filters[result.id];
-    if (filter.fidx === -1
-      && this.testTables[index]
-      && this.testTables[index][collection]
-    ) {
-      filter.fidx = this.testTables[index][collection].filtersCount;
-      this.testTables[index][collection].filtersCount++;
-    }
-
-    return response;
+    return highwayhash.asHexString(this.seed, Buffer.from(inString));
   }
 
   /**
@@ -291,6 +250,74 @@ class Storage {
     this.conditions = {};
     this.foPairs = {};
     this.testTables = {};
+  }
+
+  /**
+   * Decomposes and stores a normalized filter
+   *
+   * @param {string} index
+   * @param {string} collection
+   * @param {Array} filters
+   * @param {String} [filterId] Optional: may be computed beforehand with getFilterId
+   * @return {object}
+   */
+  store (index, collection, filters, filterId = null) {
+    const
+      result = this._addFilter(index, collection, filters, filterId),
+      response = {
+        id: result.id,
+        diff: {
+          index,
+          collection,
+          filters
+        }
+      };
+
+    if (!result.created) {
+      return response;
+    }
+
+    this._addFiltersIndex(index, collection, result.id);
+
+    let i; // NOSONAR
+
+    for(i = 0; i < filters.length; i++) {
+      const
+        sf = filters[i],
+        sfResult = this._addSubfilter(this.filters[result.id], sf);
+
+      if (sfResult.created) {
+        const
+          subfilter = this.subfilters[index][collection][sfResult.id],
+          addedConditions = this._addConditions(subfilter, index, collection, sf);
+
+        this._addTestTables(subfilter, index, collection);
+        Storage.addIndexCollectionToObject(this.foPairs, index, collection);
+
+        let j; // NOSONAR
+        for(j = 0; j < addedConditions.length; j++) {
+          const cond = addedConditions[j];
+
+          if (!this.foPairs[index][collection][cond.keyword]) {
+            this.foPairs[index][collection][cond.keyword] = new FieldOperand();
+          }
+
+          this.storeOperand[cond.keyword](this.foPairs[index][collection][cond.keyword], subfilter, cond);
+        }
+      }
+    }
+
+    // ref https://github.com/kuzzleio/kuzzle/issues/740
+    const filter = this.filters[result.id];
+    if (filter.fidx === -1
+      && this.testTables[index]
+      && this.testTables[index][collection]
+    ) {
+      filter.fidx = this.testTables[index][collection].filtersCount;
+      this.testTables[index][collection].filtersCount++;
+    }
+
+    return response;
   }
 
   /**
@@ -593,32 +620,6 @@ class Storage {
     }
   }
 
-  /**
-   * Returns the filter id calculated from its components
-   * @param  {String} index      Data index
-   * @param  {String} collection Data collection
-   * @param  {Object} filters    Normalized filters
-   * @return {String}            Filter unique ID
-   */
-  getFilterId (index, collection, filters) {
-    return this.hash({index, collection, filters});
-  }
-
-  hash (input) {
-    let inString;
-
-    switch (typeof input) {
-      case 'string':
-      case 'number':
-      case 'boolean':
-        inString = input;
-        break;
-      default:
-        inString = stringify(input);
-    }
-
-    return highwayhash.asHexString(this.seed, Buffer.from(inString));
-  }
 }
 
 module.exports = Storage;

--- a/lib/transform/canonical.js
+++ b/lib/transform/canonical.js
@@ -27,9 +27,6 @@ const
   Espresso = require('espresso-logic-minimizer').Espresso,
   strcmp = require('../util/stringCompare');
 
-// Defaults
-const defaultMaxConditions = 8;
-
 /**
  * Converts filters in canonical form
  *
@@ -38,7 +35,7 @@ const defaultMaxConditions = 8;
  */
 class Canonical {
   constructor(config) {
-    this.maxConditions = config.maxConditions || defaultMaxConditions;
+    this.config = config;
   }
 
   /**
@@ -69,7 +66,7 @@ class Canonical {
     }
 
     const conditions = this._extractConditions(filters);
-    if (conditions.length > this.maxConditions) {
+    if (this.config.maxMinTerms && conditions.length > this.config.maxMinTerms) {
       throw new BadRequestError('Maximum number of sub conditions reached.');
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Supersonic real-time data percolation engine",
   "main": "lib/index.js",
   "directories": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -32,6 +32,33 @@ describe('DSL API', () => {
     it('should throw if an invalid argument is supplied', () => {
       should(() => new Dsl('foobar')).throw(/Invalid argument: expected an object/);
       should(() => new Dsl(['foo', 'bar'])).throw(/Invalid argument: expected an object/);
+
+      should(() => new Dsl({
+        seed: 'not a buffer'
+      }))
+        .throw({message: 'Invalid seed: expected a 32 bytes long Buffer'});
+
+      should(() => new Dsl({
+        seed: require('crypto').randomBytes(24)
+      }))
+        .throw({message: 'Invalid seed: expected a 32 bytes long Buffer'});
+
+      {
+        // valid params
+        const
+          seed = Buffer.from('01234567890123456789012345678901'),
+          engine = new Dsl({
+            seed,
+            maxMinTerms: 3
+          });
+
+        should(engine.config)
+          .eql({
+            seed,
+            maxMinTerms: 3
+          });
+      }
+
     });
   });
 


### PR DESCRIPTION
* seed hash with constant value by default to
  1. respect the principle of least astonishment
  2. make koncorde by default compatible with Kuzzle cluster mode
* increase default `maxMinTerms` value to accept simple filters which can generate a relatively high number of minterms (i.e. `not in`)