### PR TITLE
[HOTFIX] Fix document flattening function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -208,12 +208,12 @@ function flattenObject(target, id) {
     output._id = id;
   }
 
-  flattenStep(output, target, null, '.');
+  flattenStep(output, target);
 
   return output;
 }
 
-function flattenStep(output, object, prev, delimiter) {
+function flattenStep(output, object, prev) {
   const keys = Object.keys(object);
   let i; // NOSONAR
 
@@ -221,11 +221,11 @@ function flattenStep(output, object, prev, delimiter) {
     const
       key = keys[i],
       value = object[key],
-      newKey = prev ? prev + delimiter + key : key;
+      newKey = prev ? prev + '.' + key : key;
 
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       output[newKey] = value;
-      return flattenStep(output, value, newKey, delimiter);
+      flattenStep(output, value, newKey);
     }
 
     output[newKey] = value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Supersonic real-time data percolation engine",
   "main": "lib/index.js",
   "directories": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -209,6 +209,51 @@ describe('DSL API', () => {
     it('should return an empty array if there is no filter registered on an index or collection', () => {
       should(dsl.test('i', 'c', {foo: 'bar'})).be.an.Array().and.be.empty();
     });
+
+    it('should flatten submitted documents', () => {
+      const stub = sinon.stub(dsl.matcher, 'match');
+
+      return dsl.register('i', 'c', {})
+        .then(() => {
+          dsl.test('i', 'c', {
+            bar: 'bar',
+            qux: 'qux',
+            obj: {
+              hello: 'world',
+              nested: {
+                another: 'one',
+                bites: 'the dust'
+              },
+              bottlesOfBeer: 99
+            },
+            arr: ['foo', 'bar'],
+            foo: 'bar'
+          });
+
+          should(stub).calledWith('i', 'c', {
+            bar: 'bar',
+            qux: 'qux',
+            obj: {
+              hello: 'world',
+              nested: {
+                another: 'one',
+                bites: 'the dust'
+              },
+              bottlesOfBeer: 99
+            },
+            'obj.hello': 'world',
+            'obj.nested': {
+              another: 'one',
+              bites: 'the dust'
+            },
+            'obj.nested.another': 'one',
+            'obj.nested.bites': 'the dust',
+            'obj.bottlesOfBeer': 99,
+            arr: ['foo', 'bar'], 
+            foo: 'bar'
+          });
+        });
+    });
   });
 
   describe('#remove', () => {


### PR DESCRIPTION
# Description

Before being tested, documents are flattened to allow nested fields to be tested (see http://docs.kuzzle.io/kuzzle-dsl/essential/nested/ )

The flattening function unexpectedly returned after the first encountered sub-object, automatically discarding any object properties defined after a nested object.

A unit test has been added to throughly test the document flattening function.

# Boyscout

Simplified the document flattening function prototypes.
