### PR TITLE
Fix regular expression simplified form

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ A `regexp` filter has the following structure, splitting the usual `/pattern/fla
 }
 ```
 
-If you don't need any modifier flag, then you can also the following simplified form:
+If you don't need any modifier flag, then you may also use the following simplified form:
 
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -967,6 +967,16 @@ A `regexp` filter has the following structure, splitting the usual `/pattern/fla
 }
 ```
 
+If you don't need any modifier flag, then you can also the following simplified form:
+
+```javascript
+{
+  regexp: {
+    attributeToTest: 'search pattern'
+  }
+}
+```
+
 **Example:**
 
 Given the following documents:

--- a/lib/storage/objects/regexpCondition.js
+++ b/lib/storage/objects/regexpCondition.js
@@ -37,7 +37,7 @@
  */
 class RegexpCondition {
   constructor(pattern, subfilter, flags) {
-    this.regexp = flags ? new RegExp(pattern, flags) : new RegExp(pattern);
+    this.regexp = new RegExp(pattern, flags);
     this.stringValue = this.regexp.toString();
     this.subfilters = [subfilter];
   }

--- a/lib/transform/standardize.js
+++ b/lib/transform/standardize.js
@@ -249,7 +249,15 @@ class Standardizer {
       throw new BadRequestError(err.message);
     }
 
-    return filter;
+    // standardize regexp to the unique format {<field>: {value, flags}}
+    return {
+      regexp: {
+        [field]: {
+          flags,
+          value: regexValue
+        }
+      }
+    };
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Supersonic real-time data percolation engine",
   "main": "lib/index.js",
   "directories": {

--- a/test/keywords/regexp.test.js
+++ b/test/keywords/regexp.test.js
@@ -56,19 +56,23 @@ describe('DSL.keyword.regexp', () => {
     });
 
     it('should validate a well-formed regular expression filter w/ flags', () => {
-      return should(dsl.validate({regexp: {foo: {value: 'foo', flags: 'i'}}})).be.fulfilledWith(true);
+      return dsl.normalize('foo', 'bar', {regexp: {foo: {value: 'foo', flags: 'i'}}})
+        .then(res => {
+          should(res.normalized).match([[{regexp:{foo:{flags:'i',value:'foo'}}}]]);
+        });
     });
 
     it('should validate a well-formed regular expression filter without flags', () => {
-      return should(dsl.validate({regexp: {foo: {value: 'foo'}}})).be.fulfilledWith(true);
+      return dsl.normalize('foo', 'bar', {regexp: {foo: {value: 'foo'}}})
+        .then(res => {
+          should(res.normalized).match([[{regexp:{foo:{flags:undefined,value:'foo'}}}]]);
+        });
     });
 
     it('should accept a simplified form', () => {
-      return dsl.validate({regexp: {
-        foo: '^bar'
-      }})
-        .then(response => {
-          should(response).be.true();
+      return dsl.normalize('foo', 'bar', {regexp: {foo: '^bar'}})
+        .then(res => {
+          should(res.normalized).match([[{regexp:{foo:{flags:undefined,value:'^bar'}}}]]);
         });
     });
 


### PR DESCRIPTION
* Fix #6 by standardizing regular expressions' simplified form into `{regexp: {attribute: {value, flags}}`, allowing this form to be stored like other regexp formats
* Add missing documentation for regexp's simplified form
* Update unit tests to ensure the standardized version is the same whatever regexp form is used