### PR TITLE
[kzl-223] add hasFilter method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,6 +134,15 @@ class Koncorde {
   }
 
   /**
+   * Check if a filter is registered for the given filter id
+   * @param filterId
+   * @returns {boolean}
+   */
+  hasFilter(filterId) {
+    return this.storage.filters.has(filterId);
+  }
+
+  /**
    * Test data against filters in the filters tree to get the matching
    * filters ID, if any
    *

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -207,6 +207,22 @@ describe('DSL API', () => {
     });
   });
 
+  describe('#hasFilter', () => {
+    it('should return false if the filter does not exist', () => {
+      should(dsl.hasFilter('i dont exist'))
+        .be.false();
+    });
+
+    it('should return true if the filter exists', () => {
+      return dsl.register('i', 'c', {equals: {foo: 'bar'}})
+        .then(response => {
+          should(dsl.hasFilter(response.id))
+            .be.true();
+        });
+
+    });
+  });
+
   describe('#test', () => {
     /*
      we only check the special case of no registered filter on the provided


### PR DESCRIPTION
This PR exposes a new method `hasFilter` method, which, given a filter id, returns if it is known from Koncorde.
This method is notably used by kuzzle cluster to check if a filter is already registered.