### PR TITLE
Fix "exists" matching as many times as there are duplicates in an array of values

### DIFF
--- a/lib/match/matchExists.js
+++ b/lib/match/matchExists.js
@@ -45,9 +45,10 @@ function matchExists (storage, testTables, document) {
       testTables.addMatch(storage.fields[key].subfilters);
 
       if (Array.isArray(document[key])) {
-        let j;
-        for (j = 0; j < document[key].length; j++) {
-          const entry = storage.fields[key].values.get(document[key][j]);
+        const uniq = new Set(document[key]);
+
+        for (const value of uniq.values()) {
+          const entry = storage.fields[key].values.get(value);
 
           if (entry) {
             testTables.addMatch(entry);

--- a/test/operands/and.test.js
+++ b/test/operands/and.test.js
@@ -3,55 +3,87 @@
 const
   should = require('should'),
   BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
-  DSL = require('../../');
+  Koncorde = require('../../');
 
-describe('DSL.operands.and', () => {
-  let dsl;
+describe('koncorde.operands.and', () => {
+  let koncorde;
 
   beforeEach(() => {
-    dsl = new DSL();
+    koncorde = new Koncorde();
   });
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({and: []})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: []})).be.rejectedWith(BadRequestError);
     });
 
     it('should reject non-array content', () => {
-      return should(dsl.validate({and: {foo: 'bar'}})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: {foo: 'bar'}})).be.rejectedWith(BadRequestError);
     });
 
     it('should reject if one of the content is not an object', () => {
-      return should(dsl.validate({and: [{equals: {foo: 'bar'}}, [{exists: {field: 'foo'}}]]})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, [{exists: {field: 'foo'}}]]})).be.rejectedWith(BadRequestError);
     });
 
     it('should reject if one of the content object does not refer to a valid keyword', () => {
-      return should(dsl.validate({and: [{equals: {foo: 'bar'}}, {foo: 'bar'}]})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, {foo: 'bar'}]})).be.rejectedWith(BadRequestError);
     });
 
     it('should reject if one of the content object is not a well-formed keyword', () => {
-      return should(dsl.validate({and: [{equals: {foo: 'bar'}}, {exists: {foo: 'bar'}}]})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, {exists: {foo: 'bar'}}]})).be.rejectedWith(BadRequestError);
     });
 
     it('should validate a well-formed "and" operand', () => {
-      return should(dsl.validate({and: [{equals: {foo: 'bar'}}, {exists: {field: 'bar'}}]})).be.fulfilledWith(true);
+      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, {exists: {field: 'bar'}}]})).be.fulfilledWith(true);
     });
   });
 
   describe('#matching', () => {
     it('should match a document with multiple AND conditions', () => {
-      return dsl.register('index', 'collection', {and: [{equals: {foo: 'bar'}}, {missing: {field: 'bar'}}, {range: {baz: {lt: 42}}}]})
+      const filters = {
+        and: [
+          { equals: { name: 'bar' } },
+          { exists: 'skills.languages["javascript"]' },
+          // { range: { baz: { lt: 42 } } }
+        ]
+      };
+
+      return koncorde.register('index', 'collection', filters)
         .then(subscription => {
-          const result = dsl.test('index', 'collection', {foo: 'bar', baz: 13});
+          const result = koncorde.test(
+            'index',
+            'collection',
+            {
+              name: 'bar',
+              // baz: 13,
+              skills: { languages: ['c++', 'javascript', 'c#'] }
+            });
 
           should(result).eql([subscription.id]);
         });
     });
 
     it('should not match if the document misses at least 1 condition', () => {
-      return dsl.register('index', 'collection', {and: [{equals: {foo: 'bar'}}, {missing: {field: 'bar'}}, {range: {baz: {lt: 42}}}]})
+      const filters = {
+        and: [
+          { equals: { name: 'bar' } },
+          { exists: 'skills.languages["javascript"]' },
+          // { range: { baz: { lt: 42 } } }
+        ]
+      };
+
+      return koncorde.register('index', 'collection', filters)
         .then(() => {
-          should(dsl.test('index', 'collection', {foo: 'bar', baz: 42})).be.an.Array().and.empty();
+          const result = koncorde.test(
+            'index',
+            'collection',
+            {
+              name: 'qux',
+              // baz: 13,
+              skills: { languages: ['ruby', 'php', 'elm', 'javascript'] }
+            });
+
+          should(result).be.an.Array().and.empty();
         });
     });
   });
@@ -60,17 +92,17 @@ describe('DSL.operands.and', () => {
     it('should destroy all associated keywords to an AND operand', () => {
       let id;
 
-      return dsl.register('index', 'collection', {and: [{equals: {foo: 'bar'}}, {missing: {field: 'bar'}}, {range: {baz: {lt: 42}}}]})
+      return koncorde.register('index', 'collection', {and: [{equals: {foo: 'bar'}}, {missing: {field: 'bar'}}, {range: {baz: {lt: 42}}}]})
         .then(subscription => {
           id = subscription.id;
-          return dsl.register('index', 'collection', {exists: {field: 'foo'}});
+          return koncorde.register('index', 'collection', {exists: {field: 'foo'}});
         })
-        .then(() => dsl.remove(id))
+        .then(() => koncorde.remove(id))
         .then(() => {
-          should(dsl.storage.foPairs.index.collection.get('exists')).be.an.Object();
-          should(dsl.storage.foPairs.index.collection.get('equals')).be.undefined();
-          should(dsl.storage.foPairs.index.collection.get('notexists')).be.undefined();
-          should(dsl.storage.foPairs.index.collection.get('range')).be.undefined();
+          should(koncorde.storage.foPairs.index.collection.get('exists')).be.an.Object();
+          should(koncorde.storage.foPairs.index.collection.get('equals')).be.undefined();
+          should(koncorde.storage.foPairs.index.collection.get('notexists')).be.undefined();
+          should(koncorde.storage.foPairs.index.collection.get('range')).be.undefined();
         });
     });
   });


### PR DESCRIPTION
# Description

Operands (and, or, bool) work by maintaining a counter of **different** conditions that must all be met before a subfilter can match.

That counter should only be decremented once per tested condition on any given subfilter. 
But when testing an array of values with `exists`, the exists matcher decrements the counter without verifying if the condition has already been verified.

For instance, the following condition: `exists: foo["bar"]` matches 2 times if the following object is tested: `{"foo": ["bar", "bar"]}`
And, if it's used in an operand waiting for, say, 2 different conditions, then that keyword can validate the entire operand by itself, even if the other condition is not verified.

This bug has been solved by making the exists matcher test only a set of unique values extracted from the array.

I checked the other matchers and they seem unaffected by this bug.

fix #24

# How to review

I dusted off the code a bit while I was reading the test files, so there are a lot of cosmetic changes that can be ignored in the unit test files. 
Just ignore them, nothing changed in these files, except for one new test that I pointed with a comment so that you can easily find where it is.