### PR TITLE
Remove kuzzle-common-objects from dependencies

### DIFF
--- a/lib/transform/canonical.js
+++ b/lib/transform/canonical.js
@@ -21,7 +21,6 @@
 
 const Combinatorics = require('js-combinatorics');
 
-const { BadRequestError } = require('kuzzle-common-objects');
 const { Espresso } = require('espresso-logic-minimizer');
 
 const strcmp = require('../util/stringCompare');
@@ -66,7 +65,7 @@ class Canonical {
 
     const conditions = this._extractConditions(filters);
     if (this.config.maxMinTerms && conditions.length > this.config.maxMinTerms) {
-      throw new BadRequestError('Maximum number of sub conditions reached.');
+      throw new Error('Maximum number of sub conditions reached.');
     }
 
     const normalized = this._normalize(filters, conditions);

--- a/lib/transform/index.js
+++ b/lib/transform/index.js
@@ -19,11 +19,6 @@
  * limitations under the License.
  */
 
-const {
-  KuzzleError,
-  InternalError: KuzzleInternalError
-} = require('kuzzle-common-objects');
-
 const Standardizer = require('./standardize');
 const Canonical = require('./canonical');
 
@@ -49,16 +44,7 @@ class Transformer {
   normalize(filters) {
     const standardized = this.standardizer.standardize(filters);
 
-    try {
-      return this.canonical.convert(standardized);
-    }
-    catch (e) {
-      if (e instanceof KuzzleError) {
-        throw e;
-      }
-
-      throw new KuzzleInternalError(e);
-    }
+    return this.canonical.convert(standardized);
   }
 
   /**

--- a/lib/transform/standardize.js
+++ b/lib/transform/standardize.js
@@ -19,7 +19,6 @@
  * limitations under the License.
  */
 
-const { BadRequestError } = require('kuzzle-common-objects');
 const RE2 = require('re2');
 
 const convertGeopoint = require('../util/convertGeopoint');
@@ -75,11 +74,11 @@ class Standardizer {
     }
 
     if (keywords.length > 1) {
-      throw new BadRequestError('Invalid filter syntax. Filters must have one keyword only');
+      throw new Error('Invalid filter syntax. Filters must have one keyword only');
     }
 
     if (!this.allowedKeywords.has(keywords[0])) {
-      throw new BadRequestError(`Unknown DSL keyword: ${keywords[0]}`);
+      throw new Error(`Unknown DSL keyword: ${keywords[0]}`);
     }
 
     return this[keywords[0]](filters);
@@ -107,7 +106,7 @@ class Standardizer {
     // Syntax: {exists: '<field name>'}
     if (typeof filter[name] === 'string') {
       if (filter[name].length === 0) {
-        throw new BadRequestError(`${name}: cannot test empty field name`);
+        throw new Error(`${name}: cannot test empty field name`);
       }
 
       return parseFieldSyntax(filter[name], name);
@@ -115,11 +114,12 @@ class Standardizer {
 
     // Syntax: {exists: {field: '<field name>'}}
     const field = mustBeNonEmptyObject(filter[name], name);
+    requireAttribute(filter[name], 'exists', 'field');
     onlyOneFieldAttribute(field, name);
     mustBeString(filter[name], name, 'field');
 
     if (filter[name].field.length === 0) {
-      throw new BadRequestError(`${name}: cannot test empty field name`);
+      throw new Error(`${name}: cannot test empty field name`);
     }
 
     return parseFieldSyntax(filter[name].field, name);
@@ -139,7 +139,7 @@ class Standardizer {
     mustBeNonEmptyArray(filter.ids, 'ids', 'values');
 
     if (filter.ids.values.findIndex(v => typeof v !== 'string') > -1) {
-      throw new BadRequestError('Array "values" in keyword "ids" can only contain strings');
+      throw new Error('Array "values" in keyword "ids" can only contain strings');
     }
 
     const result = {
@@ -191,19 +191,19 @@ class Standardizer {
     let error = null;
 
     if (index > -1) {
-      throw new BadRequestError(`"range.${rangeField}" accepts only the following attributes : gt, gte, lt, lte`);
+      throw new Error(`"range.${rangeField}" accepts only the following attributes : gt, gte, lt, lte`);
     }
 
     index = rangeValues.findIndex(v => typeof filter.range[rangeField][v] !== 'number');
 
     if (index > -1) {
-      throw new BadRequestError(`"range.${rangeField}.${rangeValues[index]}" must be a number`);
+      throw new Error(`"range.${rangeField}.${rangeValues[index]}" must be a number`);
     }
 
     rangeValues.forEach(rangeType => {
       if (rangeType.startsWith('lt')) {
         if (high !== Infinity) {
-          error = new BadRequestError(`"range.${rangeField}:" only 1 upper boundary allowed`);
+          error = new Error(`"range.${rangeField}:" only 1 upper boundary allowed`);
         }
         else {
           high = filter.range[rangeField][rangeType];
@@ -212,7 +212,7 @@ class Standardizer {
 
       if (rangeType.startsWith('gt')) {
         if (low !== -Infinity) {
-          error = new BadRequestError(`"range.${rangeField}:" only 1 lower boundary allowed`);
+          error = new Error(`"range.${rangeField}:" only 1 lower boundary allowed`);
         }
         else {
           low = filter.range[rangeField][rangeType];
@@ -225,7 +225,7 @@ class Standardizer {
     }
 
     if (high <= low) {
-      throw new BadRequestError(`"range.${rangeField}:" lower boundary must be strictly inferior to the upper one`);
+      throw new Error(`"range.${rangeField}:" lower boundary must be strictly inferior to the upper one`);
     }
 
     return filter;
@@ -251,7 +251,7 @@ class Standardizer {
       && Object.keys(filter.regexp[regexpField]).length > 0);
 
     if (!isObject && !isString) {
-      throw new BadRequestError(`regexp.${regexpField} must be either a string or a non-empty object`);
+      throw new Error(`regexp.${regexpField} must be either a string or a non-empty object`);
     }
 
     let regexValue;
@@ -262,7 +262,7 @@ class Standardizer {
     }
     else {
       if (Object.keys(filter.regexp[regexpField]).findIndex(v => ['flags', 'value'].indexOf(v) === -1) > -1) {
-        throw new BadRequestError('Keyword "regexp" can only contain the following attributes: flags, value');
+        throw new Error('Keyword "regexp" can only contain the following attributes: flags, value');
       }
 
       requireAttribute(filter.regexp[regexpField], 'regexp', 'value');
@@ -279,7 +279,7 @@ class Standardizer {
       new this.RegExpConstructor(regexValue, flags); //NOSONAR
     }
     catch (err) {
-      throw new BadRequestError(err.message);
+      throw new Error(`Cannot parse regexp expression "/${regexValue}/${flags}": ${err.message}`);
     }
 
     // standardize regexp to the unique format {<field>: {value, flags}}
@@ -320,7 +320,7 @@ class Standardizer {
     mustBeNonEmptyArray(filter.in, 'in', inValue);
 
     if (filter.in[inValue].findIndex(v => typeof v !== 'string') > -1) {
-      throw new BadRequestError(`Array "${inValue}" in keyword "in" can only contain strings`);
+      throw new Error(`Array "${inValue}" in keyword "in" can only contain strings`);
     }
 
     const result = {
@@ -364,7 +364,7 @@ class Standardizer {
         const n = Number.parseFloat(bBox[v]);
 
         if (isNaN(n)) {
-          throw new BadRequestError(`Invalid geoBoundingBox format: ${JSON.stringify(bBox)}`);
+          throw new Error(`Invalid geoBoundingBox format: ${JSON.stringify(bBox)}`);
         }
 
         standardized[v] = n;
@@ -386,7 +386,7 @@ class Standardizer {
     }
 
     if (BBOX_PROPERTIES.some(v => standardized[v] === null || standardized[v] === undefined)) {
-      throw new BadRequestError(`Unrecognized geo-point format in "geoBoundingBox.${field[0]}`);
+      throw new Error(`Unrecognized geo-point format in "geoBoundingBox.${field[0]}`);
     }
 
     return {
@@ -409,7 +409,7 @@ class Standardizer {
     const fields = mustBeNonEmptyObject(filter.geoDistance, 'geoDistance');
 
     if (fields.length !== 2 || !fields.includes('distance')) {
-      throw new BadRequestError('"geoDistance" keyword requires a document field and a "distance" attribute');
+      throw new Error('"geoDistance" keyword must (only) contain a document field and a "distance" attribute');
     }
 
     mustBeString(filter.geoDistance, 'geoDistance', 'distance');
@@ -418,7 +418,7 @@ class Standardizer {
     const point = convertGeopoint(filter.geoDistance[docField]);
 
     if (point === null) {
-      throw new BadRequestError(`geoDistance.${docField}: unrecognized point format`);
+      throw new Error(`geoDistance.${docField}: unrecognized point format`);
     }
 
     standardized.geospatial.geoDistance[docField] = {lat: point.lat, lon: point.lon};
@@ -436,7 +436,7 @@ class Standardizer {
     const fields = mustBeNonEmptyObject(filter.geoDistanceRange, 'geoDistanceRange');
 
     if (fields.length !== 3 || !fields.includes('from') || !fields.includes('to')) {
-      throw new BadRequestError('"geoDistanceRange" keyword requires a document field and the following attributes: "from", "to"');
+      throw new Error('"geoDistanceRange" keyword must (only) contain a document field and the following attributes: "from", "to"');
     }
 
     const docField = Object.keys(filter.geoDistanceRange).find(f => f !== 'from' && f !== 'to');
@@ -447,14 +447,14 @@ class Standardizer {
     const point = convertGeopoint(filter.geoDistanceRange[docField]);
 
     if (point === null) {
-      throw new BadRequestError(`geoDistanceRange.${docField}: unrecognized point format`);
+      throw new Error(`geoDistanceRange.${docField}: unrecognized point format`);
     }
 
     const from = convertDistance(filter.geoDistanceRange.from);
     const to = convertDistance(filter.geoDistanceRange.to);
 
     if (from >= to) {
-      throw new BadRequestError(`geoDistanceRange.${docField}: inner radius must be smaller than outer radius`);
+      throw new Error(`geoDistanceRange.${docField}: inner radius must be smaller than outer radius`);
     }
 
     return {
@@ -487,14 +487,14 @@ class Standardizer {
     const points = [];
 
     if (filter.geoPolygon[docField].points.length < 3) {
-      throw new BadRequestError(`"geoPolygon.${docField}": at least 3 points are required to build a polygon`);
+      throw new Error(`"geoPolygon.${docField}": at least 3 points are required to build a polygon`);
     }
 
     for (let i = 0; i < filter.geoPolygon[docField].points.length; ++i) {
       const point = convertGeopoint(filter.geoPolygon[docField].points[i]);
 
       if (point === null) {
-        throw new BadRequestError(`geoPolygon.${docField}: unrecognized point format (${JSON.stringify(filter.geoPolygon[docField].points[i])})`);
+        throw new Error(`geoPolygon.${docField}: unrecognized point format (${JSON.stringify(filter.geoPolygon[docField].points[i])})`);
       }
 
       points.push([point.lat, point.lon]);
@@ -515,8 +515,8 @@ class Standardizer {
    * @param {string} [keyword] name - user keyword entry (and, must, should_not).. used to display errors if any
    * @returns {Object} standardized filter
    */
-  and (filter, keyword = 'and') {
-    mustBeNonEmptyArray(filter, 'and', keyword);
+  and (filter) {
+    mustBeNonEmptyArray(filter, 'and');
     return this._standardizeFilterArray(filter, 'and');
   }
 
@@ -526,8 +526,8 @@ class Standardizer {
    * @param {string} [keyword] name - user keyword entry (or, should, must_not).. used to display errors if any
    * @returns {Object} standardized filter
    */
-  or (filter, keyword = 'or') {
-    mustBeNonEmptyArray(filter, 'or', keyword);
+  or (filter) {
+    mustBeNonEmptyArray(filter, 'or');
     return this._standardizeFilterArray(filter, 'or');
   }
 
@@ -586,7 +586,7 @@ class Standardizer {
     const fields = mustBeNonEmptyObject(filter.bool, 'bool');
 
     if (fields.findIndex(field => BOOL_ATTRIBUTES.indexOf(field) === -1) > -1) {
-      throw new BadRequestError(`"bool" operand accepts only the following attributes: ${BOOL_ATTRIBUTES.join(', ')}`);
+      throw new Error(`"bool" operand accepts only the following attributes: ${BOOL_ATTRIBUTES.join(', ')}`);
     }
 
     const f = {and: []};
@@ -627,7 +627,7 @@ class Standardizer {
     });
 
     if (idx > -1) {
-      throw new BadRequestError(`"${operand}" operand can only contain non-empty objects`);
+      throw new Error(`"${operand}" operand can only contain non-empty objects`);
     }
 
     const result = {
@@ -694,7 +694,7 @@ module.exports = Standardizer;
  */
 function onlyOneFieldAttribute(fieldsList, keyword) {
   if (fieldsList.length > 1) {
-    throw new BadRequestError(`"${keyword}" can contain only one attribute`);
+    throw new Error(`"${keyword}" can contain only one attribute`);
   }
 }
 
@@ -705,8 +705,8 @@ function onlyOneFieldAttribute(fieldsList, keyword) {
  * @param attribute
  */
 function requireAttribute(filter, keyword, attribute) {
-  if (!filter[attribute]) {
-    throw new BadRequestError(`"${keyword}" requires the following attribute: ${attribute}`);
+  if (filter[attribute] === undefined) {
+    throw new Error(`"${keyword}" requires the following attribute: ${attribute}`);
   }
 }
 
@@ -718,13 +718,13 @@ function requireAttribute(filter, keyword, attribute) {
  */
 function mustBeNonEmptyObject(filter, keyword) {
   if (!filter || typeof filter !== 'object' || Array.isArray(filter)) {
-    throw new BadRequestError(`"${keyword}" must be a non-empty object`);
+    throw new Error(`"${keyword}" must be a non-empty object`);
   }
 
   const fields = Object.keys(filter);
 
   if (fields.length === 0) {
-    throw new BadRequestError(`"${keyword}" must be a non-empty object`);
+    throw new Error(`"${keyword}" must be a non-empty object`);
   }
 
   return fields;
@@ -739,7 +739,7 @@ function mustBeNonEmptyObject(filter, keyword) {
  */
 function mustBeScalar (filter, keyword, field) {
   if (filter[field] instanceof Object || filter[field] === undefined) {
-    throw new BadRequestError(`"${field}" in "${keyword}" must be either a string, a number, a boolean or null`);
+    throw new Error(`"${field}" in "${keyword}" must be either a string, a number, a boolean or null`);
   }
 }
 
@@ -751,7 +751,7 @@ function mustBeScalar (filter, keyword, field) {
  */
 function mustBeString (filter, keyword, field) {
   if (typeof filter[field] !== 'string') {
-    throw new BadRequestError(`Attribute "${field}" in "${keyword}" must be a string`);
+    throw new Error(`Attribute "${field}" in "${keyword}" must be a string`);
   }
 }
 
@@ -762,12 +762,17 @@ function mustBeString (filter, keyword, field) {
  * @param field
  */
 function mustBeNonEmptyArray (filter, keyword, field) {
-  if (!Array.isArray(filter[field])) {
-    throw new BadRequestError(`Attribute "${field}" in "${keyword}" must be an array`);
+  const prefix = field
+    ? `Attribute "${field}" in "${keyword}"`
+    : `Attribute "${keyword}"`;
+  const value = field ? filter[field] : filter[keyword];
+
+  if (!Array.isArray(value)) {
+    throw new Error(`${prefix} must be an array`);
   }
 
-  if (filter[field].length === 0) {
-    throw new BadRequestError(`Attribute "${field}" in  "${keyword}" cannot be empty`);
+  if (value.length === 0) {
+    throw new Error(`${prefix} cannot be empty`);
   }
 }
 
@@ -807,7 +812,7 @@ function parseFieldSyntax(field, keyword) {
       value = JSON.parse(rawValue);
     }
     catch (error) {
-      throw new BadRequestError(`[${keyword}] Invalid array value "${rawValue}"`);
+      throw new Error(`[${keyword}] Invalid array value "${rawValue}"`);
     }
   }
 

--- a/lib/util/convertDistance.js
+++ b/lib/util/convertDistance.js
@@ -20,7 +20,6 @@
  */
 
 const units = require('node-units');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 /**
  * Converts a distance string value to a number of meters
@@ -41,7 +40,7 @@ function convertDistance (distance) {
     converted = units.convert(cleaned + ' to m');
   }
   catch (e) {
-    throw new BadRequestError(`unable to parse distance value "${distance}"`);
+    throw new Error(`unable to parse distance value "${distance}"`);
   }
 
   return converted;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,25 +12,24 @@
         "espresso-logic-minimizer": "^2.0.3",
         "js-combinatorics": "^0.6.1",
         "json-stable-stringify": "^1.0.1",
-        "kuzzle-common-objects": "^5.0.2",
         "murmurhash-native": "^3.5.0",
         "ngeohash": "^0.6.3",
         "node-interval-tree": "^1.3.3",
         "node-units": "^0.1.7",
-        "re2": "^1.15.9",
+        "re2": "^1.16.0",
         "reify": "^0.20.12"
       },
       "devDependencies": {
         "benchmark": "^2.1.4",
-        "codecov": "^3.8.1",
-        "eslint": "^7.20.0",
+        "codecov": "^3.8.2",
+        "eslint": "^7.26.0",
         "geojson-random": "^0.5.0",
-        "mocha": "^8.3.0",
+        "mocha": "^8.4.0",
         "nyc": "^15.1.0",
         "random-js": "^2.1.0",
         "should": "^13.2.3",
         "should-sinon": "0.0.6",
-        "sinon": "^9.2.4"
+        "sinon": "^10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -410,9 +409,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -422,12 +421,26 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -516,6 +529,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -555,7 +605,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -600,7 +649,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -608,11 +656,23 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
+      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -625,6 +685,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -731,22 +792,6 @@
         "node": ">=0.6.10"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -756,36 +801,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/benchmark": {
       "version": "2.1.4",
@@ -886,6 +905,135 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/cacache": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.1.0.tgz",
+      "integrity": "sha512-mfx0C+mCfWjD1PnwQ9yaOrwG1ou9FkKnx0SvzUHWdFt7r7GaRtzT+9M8HAvLu62zIHtnpQ/1m93nWNDCckJGXQ==",
+      "dependencies": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cacache/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacache/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cacache/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/tar": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -925,11 +1073,6 @@
       "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
       "dev": true
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "node_modules/chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -954,7 +1097,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -977,7 +1119,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1046,15 +1187,15 @@
       }
     },
     "node_modules/codecov": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
-      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.2.tgz",
+      "integrity": "sha512-6w/kt/xvmPsWMfDFPE/T054txA9RTgcJEw36PNa6MYX+YV29jCHCRFXwbQ3QZBTOgnex1J2WP8bo2AT8TWWz9g==",
       "dev": true,
       "dependencies": {
         "argv": "0.0.2",
         "ignore-walk": "3.0.3",
-        "js-yaml": "3.14.0",
-        "teeny-request": "6.0.1",
+        "js-yaml": "3.14.1",
+        "teeny-request": "7.0.1",
         "urlgrey": "0.4.4"
       },
       "bin": {
@@ -1062,19 +1203,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/codecov/node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/color-convert": {
@@ -1100,17 +1228,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -1154,17 +1271,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/debug": {
@@ -1218,18 +1324,18 @@
         "node": ">=8"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -1263,15 +1369,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.672",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.672.tgz",
@@ -1283,6 +1380,27 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -1297,12 +1415,17 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -1332,13 +1455,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1351,10 +1474,10 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -1362,7 +1485,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1601,28 +1724,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -1746,27 +1858,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/from2": {
@@ -1897,14 +1988,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1937,15 +2020,27 @@
       }
     },
     "node_modules/globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1963,27 +2058,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.x"
-      }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/has-flag": {
@@ -2031,11 +2105,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -2045,40 +2123,24 @@
         "node": ">= 6"
       }
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "dependencies": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6"
       }
     },
-    "node_modules/https-proxy-agent/node_modules/agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0"
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -2110,9 +2172,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2120,13 +2182,15 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -2135,10 +2199,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -2167,6 +2235,11 @@
         "install-from-cache": "bin/install-from-cache.js",
         "save-to-github-cache": "bin/save-to-github-cache.js"
       }
+    },
+    "node_modules/ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2212,6 +2285,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2242,7 +2320,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -2262,11 +2341,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -2408,9 +2482,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2419,11 +2493,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -2437,15 +2506,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
@@ -2460,11 +2525,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -2511,44 +2571,11 @@
         "node": "*"
       }
     },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "node_modules/just-extend": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
       "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
-    },
-    "node_modules/kuzzle-common-objects": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/kuzzle-common-objects/-/kuzzle-common-objects-5.0.2.tgz",
-      "integrity": "sha512-3XNx1Imgba0UHrtrMCCNc2stsEojyCKEEvhXIhAFOcLDx8vxZb7SUw+43sNtd44CJ+hXqJd7izBfl1hfysUr2A==",
-      "dependencies": {
-        "uuid": "^8.3.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/kuzzle-common-objects/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2656,24 +2683,46 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+    "node_modules/make-fetch-happen": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
+      "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
       "dependencies": {
-        "mime-db": "1.46.0"
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.0.5",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^5.0.0",
+        "ssri": "^8.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 10"
       }
+    },
+    "node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -2700,6 +2749,158 @@
         "yallist": "^3.0.0"
       }
     },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.3.tgz",
+      "integrity": "sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==",
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/minizlib": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
@@ -2720,9 +2921,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -2898,19 +3099,19 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.0.0.tgz",
+      "integrity": "sha512-Jod6NxyWtcwrpAQe0O/aXOpC5QfncotgtG73dg65z6VW/C6g/G4jiajXQUBIJ8pk/VfM6mBYE9BN/HvudTunUQ==",
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^8.0.14",
         "nopt": "^5.0.0",
         "npmlog": "^4.1.2",
-        "request": "^2.88.2",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.0",
         "which": "^2.0.2"
       },
       "bin": {
@@ -3002,9 +3203,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3389,14 +3590,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3574,11 +3767,6 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -3696,25 +3884,30 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/random-js": {
@@ -3755,14 +3948,14 @@
       }
     },
     "node_modules/re2": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/re2/-/re2-1.15.9.tgz",
-      "integrity": "sha512-AXWEhpMTBdC+3oqbjdU07dk0pBCvxh5vbOMLERL6Y8FYBSGn4vXlLe8cYszn64Yy7H8keVMrgPzoSvOd4mePpg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.16.0.tgz",
+      "integrity": "sha512-eizTZL2ZO0ZseLqfD4t3Qd0M3b3Nr0MBWpX81EbPMIud/1d/CSfUIx2GQK8fWiAeHoSekO5EOeFib2udTZLwYw==",
       "hasInstallScript": true,
       "dependencies": {
         "install-artifact-from-github": "^1.2.0",
         "nan": "^2.14.2",
-        "node-gyp": "^7.1.2"
+        "node-gyp": "^8.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -3829,37 +4022,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3891,6 +4053,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rimraf": {
@@ -4033,16 +4203,16 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "node_modules/sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
-        "nise": "^4.0.4",
+        "nise": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "funding": {
@@ -4083,6 +4253,41 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/source-map": {
@@ -4137,29 +4342,32 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
+        "minipass": "^3.1.1"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 8"
       }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ssri/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -4340,16 +4548,28 @@
       }
     },
     "node_modules/teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+      "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/test-exclude": {
@@ -4399,34 +4619,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4466,10 +4658,27 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -4489,6 +4698,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -4498,19 +4708,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5118,9 +5315,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -5130,9 +5327,19 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -5199,6 +5406,30 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -5237,8 +5468,7 @@
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -5272,16 +5502,24 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
+      }
+    },
+    "agentkeepalive": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
+      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
       }
     },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -5291,6 +5529,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5372,52 +5611,16 @@
       "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "benchmark": {
       "version": "2.1.4",
@@ -5499,6 +5702,101 @@
         "node-releases": "^1.1.70"
       }
     },
+    "cacache": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.1.0.tgz",
+      "integrity": "sha512-mfx0C+mCfWjD1PnwQ9yaOrwG1ou9FkKnx0SvzUHWdFt7r7GaRtzT+9M8HAvLu62zIHtnpQ/1m93nWNDCckJGXQ==",
+      "requires": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "tar": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+          "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -5528,11 +5826,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
       "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
       "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "4.1.0",
@@ -5568,8 +5861,7 @@
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -5622,28 +5914,16 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codecov": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
-      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.2.tgz",
+      "integrity": "sha512-6w/kt/xvmPsWMfDFPE/T054txA9RTgcJEw36PNa6MYX+YV29jCHCRFXwbQ3QZBTOgnex1J2WP8bo2AT8TWWz9g==",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
         "ignore-walk": "3.0.3",
-        "js-yaml": "3.14.0",
-        "teeny-request": "6.0.1",
+        "js-yaml": "3.14.1",
+        "teeny-request": "7.0.1",
         "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "color-convert": {
@@ -5666,14 +5946,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "commondir": {
       "version": "1.0.1",
@@ -5716,14 +5988,6 @@
         "which": "^2.0.1"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -5758,15 +6022,15 @@
         "strip-bom": "^4.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -5788,15 +6052,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.3.672",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.672.tgz",
@@ -5809,6 +6064,26 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -5819,9 +6094,14 @@
       }
     },
     "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "es6-error": {
       "version": "4.1.1",
@@ -5842,13 +6122,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -5861,10 +6141,10 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -5872,7 +6152,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -6043,25 +6323,17 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6154,21 +6426,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
       }
     },
     "from2": {
@@ -6266,14 +6523,6 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -6297,12 +6546,20 @@
       }
     },
     "globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -6315,20 +6572,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
     },
     "has-flag": {
       "version": "4.0.0",
@@ -6363,43 +6606,36 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
       }
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "agent-base": "6",
+        "debug": "4"
       }
     },
-    "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "requires": {
-        "agent-base": "5",
-        "debug": "4"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        }
+        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -6425,9 +6661,9 @@
       }
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -6437,14 +6673,17 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -6469,6 +6708,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.2.0.tgz",
       "integrity": "sha512-3OxCPcY55XlVM3kkfIpeCgmoSKnMsz2A3Dbhsq0RXpIknKQmrX1YiznCeW9cD2ItFmDxziA3w6Eg8d80AoL3oA=="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -6502,6 +6746,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6523,7 +6772,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6540,11 +6790,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -6659,19 +6904,14 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -6679,15 +6919,11 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -6702,11 +6938,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -6738,37 +6969,11 @@
         "through": ">=2.2.7 <3"
       }
     },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "just-extend": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
       "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
-    },
-    "kuzzle-common-objects": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/kuzzle-common-objects/-/kuzzle-common-objects-5.0.2.tgz",
-      "integrity": "sha512-3XNx1Imgba0UHrtrMCCNc2stsEojyCKEEvhXIhAFOcLDx8vxZb7SUw+43sNtd44CJ+hXqJd7izBfl1hfysUr2A==",
-      "requires": {
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
     },
     "levn": {
       "version": "0.4.1",
@@ -6856,17 +7061,41 @@
         }
       }
     },
-    "mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
-    },
-    "mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+    "make-fetch-happen": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
+      "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
       "requires": {
-        "mime-db": "1.46.0"
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.0.5",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^5.0.0",
+        "ssri": "^8.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "minimatch": {
@@ -6891,6 +7120,133 @@
         "yallist": "^3.0.0"
       }
     },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-fetch": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.3.tgz",
+      "integrity": "sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==",
+      "requires": {
+        "encoding": "^0.1.12",
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "minizlib": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
@@ -6908,9 +7264,9 @@
       }
     },
     "mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -7048,19 +7404,19 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.0.0.tgz",
+      "integrity": "sha512-Jod6NxyWtcwrpAQe0O/aXOpC5QfncotgtG73dg65z6VW/C6g/G4jiajXQUBIJ8pk/VfM6mBYE9BN/HvudTunUQ==",
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^8.0.14",
         "nopt": "^5.0.0",
         "npmlog": "^4.1.2",
-        "request": "^2.88.2",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.0",
         "which": "^2.0.2"
       },
       "dependencies": {
@@ -7116,9 +7472,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -7428,11 +7784,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7567,11 +7918,6 @@
         }
       }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -7658,20 +8004,25 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      }
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "random-js": {
       "version": "2.1.0",
@@ -7707,13 +8058,13 @@
       }
     },
     "re2": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/re2/-/re2-1.15.9.tgz",
-      "integrity": "sha512-AXWEhpMTBdC+3oqbjdU07dk0pBCvxh5vbOMLERL6Y8FYBSGn4vXlLe8cYszn64Yy7H8keVMrgPzoSvOd4mePpg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.16.0.tgz",
+      "integrity": "sha512-eizTZL2ZO0ZseLqfD4t3Qd0M3b3Nr0MBWpX81EbPMIud/1d/CSfUIx2GQK8fWiAeHoSekO5EOeFib2udTZLwYw==",
       "requires": {
         "install-artifact-from-github": "^1.2.0",
         "nan": "^2.14.2",
-        "node-gyp": "^7.1.2"
+        "node-gyp": "^8.0.0"
       }
     },
     "readable-stream": {
@@ -7765,33 +8116,6 @@
         "es6-error": "^4.0.1"
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7815,6 +8139,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -7944,16 +8273,16 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
-        "nise": "^4.0.4",
+        "nise": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -7982,6 +8311,30 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         }
+      }
+    },
+    "smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+    },
+    "socks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
       }
     },
     "source-map": {
@@ -8026,20 +8379,27 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+    "ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "minipass": "^3.1.1"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "stream-events": {
@@ -8183,16 +8543,24 @@
       }
     },
     "teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+      "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "test-exclude": {
@@ -8233,28 +8601,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8285,10 +8631,27 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -8307,23 +8670,14 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "npm run --silent lint && npm run unit-test",
+    "test": "npm run --silent lint && npm run test:unit:coverage",
     "lint": "eslint --max-warnings=0 ./lib ./test",
-    "unit-test": "nyc --reporter=text-summary --reporter=lcov mocha",
+    "test:unit:coverage": "nyc --reporter=text-summary --reporter=lcov mocha",
+    "test:unit": "DEBUG= npx --node-arg=--trace-warnings mocha --exit",
     "codecov": "codecov"
   },
   "repository": {
@@ -35,24 +36,23 @@
     "espresso-logic-minimizer": "^2.0.3",
     "js-combinatorics": "^0.6.1",
     "json-stable-stringify": "^1.0.1",
-    "kuzzle-common-objects": "^5.0.2",
     "murmurhash-native": "^3.5.0",
     "ngeohash": "^0.6.3",
     "node-interval-tree": "^1.3.3",
     "node-units": "^0.1.7",
-    "re2": "^1.15.9",
+    "re2": "^1.16.0",
     "reify": "^0.20.12"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "codecov": "^3.8.1",
-    "eslint": "^7.20.0",
+    "codecov": "^3.8.2",
+    "eslint": "^7.26.0",
     "geojson-random": "^0.5.0",
-    "mocha": "^8.3.0",
+    "mocha": "^8.4.0",
     "nyc": "^15.1.0",
     "random-js": "^2.1.0",
     "should": "^13.2.3",
     "should-sinon": "0.0.6",
-    "sinon": "^9.2.4"
+    "sinon": "^10.0.0"
   }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,7 +1,6 @@
 require('reify');
 
 const should = require('should').noConflict();
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const Dsl = require('../');
 const sinon = require('sinon');
@@ -70,14 +69,14 @@ describe('DSL API', () => {
       return should(dsl.validate({equals: {foo: 'bar'}})).be.fulfilledWith();
     });
 
-    it('should resolve to a BadRequestError if a filter is not valid', () => {
-      return should(dsl.validate({equals: {foo: 'bar'}, exists: 'qux'})).be.rejectedWith(BadRequestError);
+    it('should reject if a filter is not valid', () => {
+      return should(dsl.validate({equals: {foo: 'bar'}, exists: 'qux'})).be.rejected();
     });
   });
 
   describe('#register', () => {
-    it('should resolve to a BadRequestError if a filter is not valid', () => {
-      return should(dsl.register('i', 'c', {foo: 'bar'})).be.rejectedWith(BadRequestError);
+    it('should reject if a filter is not valid', () => {
+      return should(dsl.register('i', 'c', {foo: 'bar'})).be.rejected();
     });
 
     it('should resolve to a cluster diff object if the registration succeeds', () => {

--- a/test/keywords/equals.test.js
+++ b/test/keywords/equals.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const DSL = require('../../');
@@ -17,49 +16,55 @@ describe('DSL.keyword.equals', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({equals: ['foo', 'bar']})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({equals: ['foo', 'bar']}))
+        .be.rejectedWith('"equals" must be a non-empty object');
     });
 
     it('should reject filters with more than 1 field', () => {
-      return should(dsl.validate({equals: {foo: 'foo', bar: 'bar'}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({equals: {foo: 'foo', bar: 'bar'}}))
+        .be.rejectedWith('"equals" can contain only one attribute');
     });
 
     it('should reject filters with array argument', () => {
-      return should(dsl.validate({equals: {foo: ['bar']}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({equals: {foo: ['bar']}}))
+        .be.rejectedWith('"foo" in "equals" must be either a string, a number, a boolean or null');
     });
 
     it('should validate filters with number argument', () => {
-      return should(dsl.validate({equals: {foo: 42}})).be.fulfilledWith();
+      return should(dsl.validate({equals: {foo: 42}})).be.fulfilled();
     });
 
     it('should reject filters with object argument', () => {
-      return should(dsl.validate({equals: {foo: {}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({equals: {foo: {}}}))
+        .be.rejectedWith('"foo" in "equals" must be either a string, a number, a boolean or null');
     });
 
     it('should reject filters with undefined argument', () => {
-      return should(dsl.validate({equals: {foo: undefined}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({equals: {foo: undefined}}))
+        .be.rejectedWith('"foo" in "equals" must be either a string, a number, a boolean or null');
     });
 
     it('should validate filters with null argument', () => {
-      return should(dsl.validate({equals: {foo: null}})).be.fulfilledWith();
+      return should(dsl.validate({equals: {foo: null}})).be.fulfilled();
     });
 
     it('should validate filters with boolean argument', () => {
-      return should(dsl.validate({equals: {foo: true}})).be.fulfilledWith();
+      return should(dsl.validate({equals: {foo: true}})).be.fulfilled();
     });
 
     it('should validate filters with a string argument', () => {
-      return should(dsl.validate({equals: {foo: 'bar'}})).be.fulfilledWith();
+      return should(dsl.validate({equals: {foo: 'bar'}})).be.fulfilled();
     });
 
     it('should validate filters with an empty string argument', () => {
-      return should(dsl.validate({equals: {foo: ''}})).be.fulfilledWith();
+      return should(dsl.validate({equals: {foo: ''}})).be.fulfilled();
     });
   });
 
   describe('#standardization', () => {
     it('should return the same content, unchanged', () => {
-      should(dsl.transformer.standardizer.standardize({equals: {foo: 'bar'}})).match({equals: {foo: 'bar'}});
+      should(dsl.transformer.standardizer.standardize({equals: {foo: 'bar'}}))
+        .match({equals: {foo: 'bar'}});
     });
   });
 

--- a/test/keywords/exists.test.js
+++ b/test/keywords/exists.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const Koncorde = require('../../');
@@ -15,66 +14,71 @@ describe('Koncorde.keyword.exists', () => {
   describe('#validation', () => {
     it('should reject empty filters', () => {
       return should(koncorde.validate({exists: {}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('"exists" must be a non-empty object');
     });
 
     it('should reject filters with more than 1 field', () => {
       return should(koncorde.validate({exists: {field: 'foo', bar: 'bar'}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('"exists" can contain only one attribute');
+    });
+
+    it('should reject filters in object-form without a "field" attribute', () => {
+      return should(koncorde.validate({exists: {foo: 'bar'}}))
+        .be.rejectedWith('"exists" requires the following attribute: field');
     });
 
     it('should reject filters with array argument', () => {
       return should(koncorde.validate({exists: {field: ['bar']}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('Attribute "field" in "exists" must be a string');
     });
 
     it('should reject filters with number argument', () => {
       return should(koncorde.validate({exists: {field: 42}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('Attribute "field" in "exists" must be a string');
     });
 
     it('should reject filters with object argument', () => {
       return should(koncorde.validate({exists: {field: {}}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('Attribute "field" in "exists" must be a string');
     });
 
     it('should reject filters with undefined argument', () => {
       return should(koncorde.validate({exists: {field: undefined}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('"exists" requires the following attribute: field');
     });
 
     it('should reject filters with null argument', () => {
       return should(koncorde.validate({exists: {field: null}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('Attribute "field" in "exists" must be a string');
     });
 
     it('should reject filters with boolean argument', () => {
       return should(koncorde.validate({exists: {field: true}}))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith('Attribute "field" in "exists" must be a string');
     });
 
     it('should validate filters with a string argument', () => {
       return should(koncorde.validate({exists: {field: 'bar'}}))
-        .be.fulfilledWith();
+        .be.fulfilled();
     });
 
     it('should reject filters with an empty string argument', () => {
-      return should(koncorde.validate({exists: {field: ''}})).be.rejectedWith(
-        BadRequestError, {message: 'exists: cannot test empty field name'});
+      return should(koncorde.validate({exists: {field: ''}}))
+        .be.rejectedWith('exists: cannot test empty field name');
     });
 
     it('should validate filters written in simplified form', () => {
-      return should(koncorde.validate({exists: 'bar'})).fulfilledWith();
+      return should(koncorde.validate({exists: 'bar'})).fulfilled();
     });
 
     it('should reject a filter in simplified form with an empty value', () => {
-      return should(koncorde.validate({exists: ''})).rejectedWith(
-        BadRequestError, {message: 'exists: cannot test empty field name'});
+      return should(koncorde.validate({exists: ''}))
+        .rejectedWith('exists: cannot test empty field name');
     });
 
     it('should reject incorrectly formatted array search filters', () => {
-      return should(koncorde.validate({exists: 'foo[\'bar\']'})).rejectedWith(
-        BadRequestError, {message: '[exists] Invalid array value "\'bar\'"'});
+      return should(koncorde.validate({exists: 'foo[\'bar\']'}))
+        .rejectedWith('[exists] Invalid array value "\'bar\'"');
     });
   });
 

--- a/test/keywords/geoBoundingBox.test.js
+++ b/test/keywords/geoBoundingBox.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const DSL = require('../../');
@@ -31,11 +30,13 @@ describe('DSL.keyword.geoBoundingBox', () => {
 
   describe('#validation/standardization', () => {
     it('should reject an empty filter', () => {
-      should(() => standardize({geoBoundingBox: {}})).throw(BadRequestError);
+      should(() => standardize({geoBoundingBox: {}}))
+        .throw('"geoBoundingBox" must be a non-empty object');
     });
 
     it('should reject a filter with multiple field attributes', () => {
-      should(() => standardize({geoBoundingBox: {foo: bbox, bar: bbox}})).throw(BadRequestError);
+      should(() => standardize({geoBoundingBox: {foo: bbox, bar: bbox}}))
+        .throw('"geoBoundingBox" can contain only one attribute');
     });
 
     it('should validate a {top, left, bottom, right} bbox', () => {
@@ -125,10 +126,18 @@ describe('DSL.keyword.geoBoundingBox', () => {
       should(result.geospatial).be.an.Object();
       should(result.geospatial.geoBoundingBox).be.an.Object();
       should(result.geospatial.geoBoundingBox.foo).be.an.Object();
-      should(result.geospatial.geoBoundingBox.foo.top).be.approximately(box.top, 10e-7);
-      should(result.geospatial.geoBoundingBox.foo.bottom).be.approximately(box.bottom, 10e-7);
-      should(result.geospatial.geoBoundingBox.foo.left).be.approximately(box.left, 10e-7);
-      should(result.geospatial.geoBoundingBox.foo.right).be.approximately(box.right, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.top)
+        .be.approximately(box.top, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.bottom)
+        .be.approximately(box.bottom, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.left)
+        .be.approximately(box.left, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.right)
+        .be.approximately(box.right, 10e-7);
     });
 
     it('should validate a {top_left: "geohash", bottom_right: "geohash"} bbox', () => {
@@ -147,10 +156,18 @@ describe('DSL.keyword.geoBoundingBox', () => {
       should(result.geospatial).be.an.Object();
       should(result.geospatial.geoBoundingBox).be.an.Object();
       should(result.geospatial.geoBoundingBox.foo).be.an.Object();
-      should(result.geospatial.geoBoundingBox.foo.top).be.approximately(box.top, 10e-7);
-      should(result.geospatial.geoBoundingBox.foo.bottom).be.approximately(box.bottom, 10e-7);
-      should(result.geospatial.geoBoundingBox.foo.left).be.approximately(box.left, 10e-7);
-      should(result.geospatial.geoBoundingBox.foo.right).be.approximately(box.right, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.top)
+        .be.approximately(box.top, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.bottom)
+        .be.approximately(box.bottom, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.left)
+        .be.approximately(box.left, 10e-7);
+
+      should(result.geospatial.geoBoundingBox.foo.right)
+        .be.approximately(box.right, 10e-7);
     });
 
     it('should reject an unrecognized bbox format', () => {
@@ -159,7 +176,8 @@ describe('DSL.keyword.geoBoundingBox', () => {
         bottom_right: '40.01 / -71.12',
       };
 
-      should(() => standardize({geoBoundingBox: {foo: box}})).throw(BadRequestError);
+      should(() => standardize({geoBoundingBox: {foo: box}}))
+        .throw('Unrecognized geo-point format in "geoBoundingBox.foo');
     });
 
     it('should reject a non-convertible bbox point string', () => {
@@ -170,9 +188,8 @@ describe('DSL.keyword.geoBoundingBox', () => {
         right: 'foobar'
       };
 
-      should(() => standardize({geoBoundingBox: {foo: box}})).throw(
-        BadRequestError,
-        { message: `Invalid geoBoundingBox format: ${JSON.stringify(box)}` });
+      should(() => standardize({geoBoundingBox: {foo: box}}))
+        .throw(`Invalid geoBoundingBox format: ${JSON.stringify(box)}`);
     });
   });
 

--- a/test/keywords/geoDistance.test.js
+++ b/test/keywords/geoDistance.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const DSL = require('../../');
@@ -27,94 +26,124 @@ describe('DSL.keyword.geoDistance', () => {
 
   describe('#validation/standardization', () => {
     it('should reject an empty filter', () => {
-      should(() => standardize({geoDistance: {}})).throw(BadRequestError);
+      should(() => standardize({geoDistance: {}}))
+        .throw('"geoDistance" must be a non-empty object');
     });
 
     it('should reject a filter with multiple field attributes', () => {
-      should(() => standardize({geoDistance: {foo: point, bar: point, distance: '1km'}})).throw(BadRequestError);
+      const filter = {geoDistance: {foo: point, bar: point, distance: '1km'}};
+
+      should(() => standardize(filter)).throw('"geoDistance" keyword must (only) contain a document field and a "distance" attribute');
     });
 
     it('should validate a {lat, lon} point', () => {
-      should(standardize({geoDistance: {foo: point, distance: '1km'}})).match(distanceStandardized);
+      should(standardize({geoDistance: {foo: point, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: [lat, lon]} point', () => {
       const p = {latLon: [point.lat, point.lon]};
-      should(standardize({geoDistance: {foo: p, distance: '1km'}})).match(distanceStandardized);
+      should(standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {lat_lon: [lat, lon]} point', () => {
       const p = {lat_lon: [point.lat, point.lon]};
-      should(standardize({geoDistance: {foo: p, distance: '1km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: {lat: lat, lon: lon}} point', () => {
       const p = {latLon: {lat: point.lat, lon: point.lon}};
-      should(standardize({geoDistance: {foo: p, distance: '1km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {lat_lon: {lat: lat, lon: lon}} point', () => {
       const p = {lat_lon: {lat: point.lat, lon: point.lon}};
-      should(standardize({geoDistance: {foo: p, distance: '1km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: "lat, lon"} point', () => {
       const p = {latLon: `${point.lat}, ${point.lon}`};
-      should(standardize({geoDistance: {foo: p, distance: '1km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {lat_lon: "lat, lon"} point', () => {
       const p = {lat_lon: `${point.lat}, ${point.lon}`};
-      should(standardize({geoDistance: {foo: p, distance: '1km'}})).match(distanceStandardized);
+      should(standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: "geohash"} point', () => {
       const p = {latLon: 'spf8prntv18e'};
-
       const result = standardize({geoDistance: {foo: p, distance: '1km'}});
+
       should(result).be.an.Object();
       should(result.geospatial).be.an.Object();
       should(result.geospatial.geoDistance).be.an.Object();
       should(result.geospatial.geoDistance.foo).be.an.Object();
       should(result.geospatial.geoDistance.foo.distance).be.eql(1000);
-      should(result.geospatial.geoDistance.foo.lat).be.approximately(point.lat, 10e-7);
-      should(result.geospatial.geoDistance.foo.lon).be.approximately(point.lon, 10e-7);
+
+      should(result.geospatial.geoDistance.foo.lat)
+        .be.approximately(point.lat, 10e-7);
+
+      should(result.geospatial.geoDistance.foo.lon)
+        .be.approximately(point.lon, 10e-7);
     });
 
     it('should validate a {lat_lon: "geohash"} point', () => {
       const p = {lat_lon: 'spf8prntv18e'};
-
       const result = standardize({geoDistance: {foo: p, distance: '1km'}});
+
       should(result).be.an.Object();
       should(result.geospatial).be.an.Object();
       should(result.geospatial.geoDistance).be.an.Object();
       should(result.geospatial.geoDistance.foo).be.an.Object();
       should(result.geospatial.geoDistance.foo.distance).be.eql(1000);
-      should(result.geospatial.geoDistance.foo.lat).be.approximately(point.lat, 10e-7);
-      should(result.geospatial.geoDistance.foo.lon).be.approximately(point.lon, 10e-7);
+
+      should(result.geospatial.geoDistance.foo.lat)
+        .be.approximately(point.lat, 10e-7);
+
+      should(result.geospatial.geoDistance.foo.lon)
+        .be.approximately(point.lon, 10e-7);
     });
 
     it('should reject an unrecognized point format', () => {
       const p = {foo: 'bar'};
-      should(() => standardize({geoDistance: {foo: p, distance: '1km'}})).throw(BadRequestError);
+
+      should(() => standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .throw('geoDistance.foo: unrecognized point format');
     });
 
     it('should reject an invalid latLon argument type', () => {
       const p = {latLon: 42};
-      should(() => standardize({geoDistance: {foo: p, distance: '1km'}})).throw(BadRequestError);
+
+      should(() => standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .throw('geoDistance.foo: unrecognized point format');
     });
 
     it('should reject an invalid latLon argument string', () => {
       const p = {latLon: '[10, 10]'};
-      should(() => standardize({geoDistance: {foo: p, distance: '1km'}})).throw(BadRequestError);
+
+      should(() => standardize({geoDistance: {foo: p, distance: '1km'}}))
+        .throw('geoDistance.foo: unrecognized point format');
     });
 
     it('should reject a filter with a non-string distance value', () => {
-      should(() => standardize({geoDistance: {foo: point, distance: 42}})).throw(BadRequestError);
+      should(() => standardize({geoDistance: {foo: point, distance: 42}}))
+        .throw('Attribute "distance" in "geoDistance" must be a string');
     });
 
     it('should reject a filter with incorrect distance value', () => {
-      should(() => standardize({geoDistance: {foo: point, distance: '1 ly'}})).throw(BadRequestError);
+      should(() => standardize({geoDistance: {foo: point, distance: '1 ly'}}))
+        .throw('unable to parse distance value "1 ly"');
     });
   });
 

--- a/test/keywords/geoDistanceRange.test.js
+++ b/test/keywords/geoDistanceRange.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const DSL = require('../../');
@@ -28,108 +27,173 @@ describe('DSL.keyword.geoDistanceRange', () => {
 
   describe('#validation/standardization', () => {
     it('should reject an empty filter', () => {
-      should(() => standardize({geoDistanceRange: {}})).throw(BadRequestError);
+      should(() => standardize({geoDistanceRange: {}}))
+        .throw('"geoDistanceRange" must be a non-empty object');
     });
 
     it('should reject a filter with multiple field attributes', () => {
-      should(() => standardize({geoDistanceRange: {foo: point, bar: point, from: '1km', to: '10km'}})).throw(BadRequestError);
+      const filter = {foo: point, bar: point, from: '1km', to: '10km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('"geoDistanceRange" keyword must (only) contain a document field and the following attributes: "from", "to"');
     });
 
     it('should validate a {lat, lon} point', () => {
-      should(standardize({geoDistanceRange: {foo: point, from: '1km', to: '10km'}})).match(distanceStandardized);
+      const filter = {foo: point, from: '1km', to: '10km'};
+
+      should(standardize({geoDistanceRange: filter}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: [lat, lon]} point', () => {
       const p = {latLon: [point.lat, point.lon]};
-      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {lat_lon: [lat, lon]} point', () => {
       const p = {lat_lon: [point.lat, point.lon]};
-      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: {lat: lat, lon: lon}} point', () => {
       const p = {latLon: {lat: point.lat, lon: point.lon}};
-      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {lat_lon: {lat: lat, lon: lon}} point', () => {
       const p = {lat_lon: {lat: point.lat, lon: point.lon}};
-      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: "lat, lon"} point', () => {
       const p = {latLon: `${point.lat}, ${point.lon}`};
-      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {lat_lon: "lat, lon"} point', () => {
       const p = {lat_lon: `${point.lat}, ${point.lon}`};
-      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).match(distanceStandardized);
+
+      should(standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}}))
+        .match(distanceStandardized);
     });
 
     it('should validate a {latLon: "geohash"} point', () => {
       const p = {latLon: 'spf8prntv18e'};
 
-      const result = standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}});
+      const result = standardize({
+        geoDistanceRange: {
+          foo: p,
+          from: '1km',
+          to: '10km',
+        }
+      });
+
       should(result).be.an.Object();
       should(result.geospatial).be.an.Object();
       should(result.geospatial.geoDistanceRange).be.an.Object();
       should(result.geospatial.geoDistanceRange.foo).be.an.Object();
       should(result.geospatial.geoDistanceRange.foo.from).be.eql(1000);
       should(result.geospatial.geoDistanceRange.foo.to).be.eql(10000);
-      should(result.geospatial.geoDistanceRange.foo.lat).be.approximately(point.lat, 10e-7);
-      should(result.geospatial.geoDistanceRange.foo.lon).be.approximately(point.lon, 10e-7);
+
+      should(result.geospatial.geoDistanceRange.foo.lat)
+        .be.approximately(point.lat, 10e-7);
+
+      should(result.geospatial.geoDistanceRange.foo.lon)
+        .be.approximately(point.lon, 10e-7);
     });
 
     it('should validate a {lat_lon: "geohash"} point', () => {
       const p = {lat_lon: 'spf8prntv18e'};
 
-      const result = standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}});
+      const result = standardize({
+        geoDistanceRange: {
+          foo: p,
+          from: '1km',
+          to: '10km',
+        },
+      });
+
       should(result).be.an.Object();
       should(result.geospatial).be.an.Object();
       should(result.geospatial.geoDistanceRange).be.an.Object();
       should(result.geospatial.geoDistanceRange.foo).be.an.Object();
       should(result.geospatial.geoDistanceRange.foo.from).be.eql(1000);
       should(result.geospatial.geoDistanceRange.foo.to).be.eql(10000);
-      should(result.geospatial.geoDistanceRange.foo.lat).be.approximately(point.lat, 10e-7);
-      should(result.geospatial.geoDistanceRange.foo.lon).be.approximately(point.lon, 10e-7);
+
+      should(result.geospatial.geoDistanceRange.foo.lat)
+        .be.approximately(point.lat, 10e-7);
+
+      should(result.geospatial.geoDistanceRange.foo.lon)
+        .be.approximately(point.lon, 10e-7);
     });
 
     it('should reject an unrecognized point format', () => {
       const p = {foo: 'bar'};
-      should(() => standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).throw(BadRequestError);
+      const filter = {foo: p, from: '1km', to: '10km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('geoDistanceRange.foo: unrecognized point format');
     });
 
     it('should reject an invalid latLon argument type', () => {
       const p = {latLon: 42};
-      should(() => standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).throw(BadRequestError);
+      const filter = {foo: p, from: '1km', to: '10km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('geoDistanceRange.foo: unrecognized point format');
     });
 
     it('should reject an invalid latLon argument string', () => {
       const p = {latLon: '[10, 10]'};
-      should(() => standardize({geoDistanceRange: {foo: p, from: '1km', to: '10km'}})).throw(BadRequestError);
+      const filter = {foo: p, from: '1km', to: '10km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('geoDistanceRange.foo: unrecognized point format');
     });
 
     it('should reject a filter with a non-string from value', () => {
-      should(() => standardize({geoDistanceRange: {foo: point, from: 42, to: '10km'}})).throw(BadRequestError);
+      const filter = {foo: point, from: 42, to: '10km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('Attribute "from" in "geoDistanceRange" must be a string');
     });
 
     it('should reject a filter with a non-string to value', () => {
-      should(() => standardize({geoDistanceRange: {foo: point, from: '1km', to: 42}})).throw(BadRequestError);
+      const filter = {foo: point, from: '1km', to: 42};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('Attribute "to" in "geoDistanceRange" must be a string');
     });
 
     it('should reject a filter with incorrect from value', () => {
-      should(() => standardize({geoDistanceRange: {foo: point, from: '1 micronanomillimeter', to: '1km'}})).throw(BadRequestError);
+      const filter = {foo: point, from: '1 micronanomillimeter', to: '1km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('unable to parse distance value "1 micronanomillimeter"');
     });
 
     it('should reject a filter with incorrect to value', () => {
-      should(() => standardize({geoDistanceRange: {foo: point, from: '1 km', to: '1 ly'}})).throw(BadRequestError);
+      const filter = {foo: point, from: '1 km', to: '1 ly'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('unable to parse distance value "1 ly"');
     });
 
     it('should reject a filter with a negative range', () => {
-      should(() => standardize({geoDistanceRange: {foo: point, from: '10 km', to: '1km'}})).throw(BadRequestError);
+      const filter = {foo: point, from: '10 km', to: '1km'};
+
+      should(() => standardize({geoDistanceRange: filter}))
+        .throw('geoDistanceRange.foo: inner radius must be smaller than outer radius');
     });
   });
 

--- a/test/keywords/geoPolygon.test.js
+++ b/test/keywords/geoPolygon.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const DSL = require('../../');
@@ -45,33 +44,42 @@ describe('DSL.keyword.geoPolygon', () => {
 
   describe('#validation/standardization', () => {
     it('should reject an empty filter', () => {
-      should(() => standardize({geoPolygon: {}})).throw(BadRequestError);
+      should(() => standardize({geoPolygon: {}}))
+        .throw('"geoPolygon" must be a non-empty object');
     });
 
     it('should reject a filter with multiple field attributes', () => {
-      should(() => standardize({geoPolygon: {foo: polygon, bar: polygon}})).throw(BadRequestError);
+      should(() => standardize({geoPolygon: {foo: polygon, bar: polygon}}))
+        .throw('"geoPolygon" can contain only one attribute');
     });
 
     it('should reject a filter without a points field', () => {
-      should(() => standardize({geoPolygon: {foo: {bar: [[0, 0], [5, 5], [5, 0]]}}})).throw(BadRequestError);
+      const filter = {foo: {bar: [[0, 0], [5, 5], [5, 0]]}};
+
+      should(() => standardize({geoPolygon: filter}))
+        .throw('"geoPolygon.foo" requires the following attribute: points');
     });
 
     it('should reject a filter with an empty points field', () => {
-      should(() => standardize({geoPolygon: {foo: {points: []}}})).throw(BadRequestError);
+      should(() => standardize({geoPolygon: {foo: {points: []}}}))
+        .throw('Attribute "points" in "geoPolygon.foo" cannot be empty');
     });
 
     it('should reject a polygon with less than 3 points defined', () => {
-      should(() => standardize({geoPolygon: {foo: {points: [[0, 0], [5, 5]]}}})).throw(BadRequestError);
+      should(() => standardize({geoPolygon: {foo: {points: [[0, 0], [5, 5]]}}}))
+        .throw('"geoPolygon.foo": at least 3 points are required to build a polygon');
     });
 
     it('should reject a polygon with a non-array points field', () => {
-      should(() => standardize({geoPolygon: {foo: {points: 'foobar'}}})).throw(BadRequestError);
+      should(() => standardize({geoPolygon: {foo: {points: 'foobar'}}}))
+        .throw('Attribute "points" in "geoPolygon.foo" must be an array');
     });
 
     it('should reject a polygon containing an invalid point format', () => {
       const p = polygon.points.slice();
       p.push(42);
-      should(() => standardize({geoPolygon: {foo: {points: p}}})).throw(BadRequestError);
+      should(() => standardize({geoPolygon: {foo: {points: p}}}))
+        .throw(/^geoPolygon.foo: unrecognized point format/);
     });
 
     it('should standardize all geopoint types in a single points array', () => {

--- a/test/keywords/ids.test.js
+++ b/test/keywords/ids.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 const DSL = require('../../');
 
 describe('DSL.keyword.ids', () => {
@@ -11,31 +10,38 @@ describe('DSL.keyword.ids', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({ids: {}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({ids: {}}))
+        .be.rejectedWith('"ids" must be a non-empty object');
     });
 
     it('should reject filters with other fields other than the "values" one', () => {
-      return should(dsl.validate({ids: {foo: ['foo']}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({ids: {foo: ['foo']}}))
+        .be.rejectedWith('"ids" requires the following attribute: values');
     });
 
     it('should reject filters with multiple defined attributes', () => {
-      return should(dsl.validate({ids: {values: ['foo'], foo: ['foo']}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({ids: {values: ['foo'], foo: ['foo']}}))
+        .be.rejectedWith('"ids" can contain only one attribute');
     });
 
     it('should reject filters with an empty value list', () => {
-      return should(dsl.validate({ids: {values: []}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({ids: {values: []}}))
+        .be.rejectedWith('Attribute "values" in "ids" cannot be empty');
     });
 
     it('should reject filters with non-array values attribute', () => {
-      return should(dsl.validate({ids: {values: 'foo'}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({ids: {values: 'foo'}}))
+        .be.rejectedWith('Attribute "values" in "ids" must be an array');
     });
 
     it('should reject filters containing a non-string value', () => {
-      return should(dsl.validate({ids: {values: ['foo', 'bar', 42, 'baz']}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({ids: {values: ['foo', 'bar', 42, 'baz']}}))
+        .be.rejectedWith('Array "values" in keyword "ids" can only contain strings');
     });
 
     it('should validate a well-formed ids filter', () => {
-      return should(dsl.validate({ids: {values: ['foo', 'bar', 'baz']}})).be.fulfilledWith();
+      return should(dsl.validate({ids: {values: ['foo', 'bar', 'baz']}}))
+        .be.fulfilled();
     });
   });
 

--- a/test/keywords/in.test.js
+++ b/test/keywords/in.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 const DSL = require('../../');
 
 describe('DSL.keyword.in', () => {
@@ -11,27 +10,33 @@ describe('DSL.keyword.in', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({in: {}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({in: {}}))
+        .be.rejectedWith('"in" must be a non-empty object');
     });
 
     it('should reject filters with multiple defined attributes', () => {
-      return should(dsl.validate({in: {bar: ['foo'], foo: ['foo']}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({in: {bar: ['foo'], foo: ['foo']}}))
+        .be.rejectedWith('"in" can contain only one attribute');
     });
 
     it('should reject filters with an empty value list', () => {
-      return should(dsl.validate({in: {foo: []}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({in: {foo: []}}))
+        .be.rejectedWith('Attribute "foo" in "in" cannot be empty');
     });
 
     it('should reject filters with non-array values attribute', () => {
-      return should(dsl.validate({in: {foo: 'foo'}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({in: {foo: 'foo'}}))
+        .be.rejectedWith('Attribute "foo" in "in" must be an array');
     });
 
     it('should reject filters containing a non-string value', () => {
-      return should(dsl.validate({in: {foo: ['foo', 'bar', 42, 'baz']}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({in: {foo: ['foo', 'bar', 42, 'baz']}}))
+        .be.rejectedWith('Array "foo" in keyword "in" can only contain strings');
     });
 
     it('should validate a well-formed ids filter', () => {
-      return should(dsl.validate({in: {foo: ['foo', 'bar', 'baz']}})).be.fulfilledWith();
+      return should(dsl.validate({in: {foo: ['foo', 'bar', 'baz']}}))
+        .be.fulfilled();
     });
   });
 

--- a/test/keywords/range.test.js
+++ b/test/keywords/range.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const RangeCondition = require('../../lib/storage/objects/rangeCondition');
@@ -14,39 +13,48 @@ describe('DSL.keyword.range', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({range: {}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {}}))
+        .be.rejectedWith('"range" must be a non-empty object');
     });
 
     it('should reject filters with more than 1 field', () => {
-      return should(dsl.validate({range: {foo: 'foo', bar: 'bar'}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: 'foo', bar: 'bar'}}))
+        .be.rejectedWith('"range" can contain only one attribute');
     });
 
     it('should reject an empty field definition', () => {
-      return should(dsl.validate({range: {foo: {}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: {}}}))
+        .be.rejectedWith('"range.foo" must be a non-empty object');
     });
 
     it('should reject a field definition containing an unrecognized range keyword', () => {
-      return should(dsl.validate({range: {foo: {gt: 42, lt: 113, bar: 'baz'}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: {gt: 42, lt: 113, bar: 'baz'}}}))
+        .be.rejectedWith('"range.foo" accepts only the following attributes : gt, gte, lt, lte');
     });
 
     it('should reject a field definition with a range keyword not containing a number', () => {
-      return should(dsl.validate({range: {foo: {gt: '42', lt: 113}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: {gt: '42', lt: 113}}}))
+        .be.rejectedWith('"range.foo.gt" must be a number');
     });
 
     it('should reject a field definition containing more than 1 lower boundary', () => {
-      return should(dsl.validate({range: {foo: {gt: 42, gte: 13, lt: 113}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: {gt: 42, gte: 13, lt: 113}}}))
+        .be.rejectedWith('"range.foo:" only 1 lower boundary allowed');
     });
 
     it('should reject a field definition containing more than 1 upper boundary', () => {
-      return should(dsl.validate({range: {foo: {gt: 42, lt: 113, lte: 200}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: {gt: 42, lt: 113, lte: 200}}}))
+        .be.rejectedWith('"range.foo:" only 1 upper boundary allowed');
     });
 
     it('should validate a valid range filter', () => {
-      return should(dsl.validate({range: {foo: {gt: 42, lte: 200}}})).be.fulfilledWith();
+      return should(dsl.validate({range: {foo: {gt: 42, lte: 200}}}))
+        .be.fulfilled();
     });
 
     it('should reject a range filter with inverted boundaries', () => {
-      return should(dsl.validate({range: {foo: {lt: 42, gt: 200}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({range: {foo: {lt: 42, gt: 200}}}))
+        .be.rejectedWith('"range.foo:" lower boundary must be strictly inferior to the upper one');
     });
   });
 

--- a/test/keywords/regexp.test.js
+++ b/test/keywords/regexp.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 const FieldOperand = require('../../lib/storage/objects/fieldOperand');
 const RegexpCondition = require('../../lib/storage/objects/regexpCondition');
 const DSL = require('../../');
@@ -13,31 +12,42 @@ describe('DSL.keyword.regexp', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({regexp: {}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({regexp: {}}))
+        .be.rejectedWith('"regexp" must be a non-empty object');
     });
 
     it('should reject filters with more than 1 field', () => {
-      return should(dsl.validate({regexp: {foo: {value: 'foo'}, bar: {value: 'foo'}}})).be.rejectedWith(BadRequestError);
+      const filter = {foo: {value: 'foo'}, bar: {value: 'foo'}};
+
+      return should(dsl.validate({regexp: filter}))
+        .be.rejectedWith('"regexp" can contain only one attribute');
     });
 
     it('should reject filters with an empty field object', () => {
-      return should(dsl.validate({regexp: {foo: {}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({regexp: {foo: {}}}))
+        .be.rejectedWith('regexp.foo must be either a string or a non-empty object');
     });
 
     it('should reject filters with other fields defined other than the accepted ones', () => {
-      return should(dsl.validate({regexp: {foo: {value: 'foo', flags: 'ig', bar: 'qux'}}})).be.rejectedWith(BadRequestError);
+      const filter = {foo: {value: 'foo', flags: 'ig', bar: 'qux'}};
+
+      return should(dsl.validate({regexp: filter}))
+        .be.rejectedWith('Keyword "regexp" can only contain the following attributes: flags, value');
     });
 
     it('should reject filters if the "value" attribute is not defined', () => {
-      return should(dsl.validate({regexp: {foo: {flags: 'ig'}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({regexp: {foo: {flags: 'ig'}}}))
+        .be.rejectedWith('"regexp" requires the following attribute: value');
     });
 
     it('should reject filters with a non-string "flags" attribute', () => {
-      return should(dsl.validate({regexp: {foo: {value: 'foo', flags: 42}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({regexp: {foo: {value: 'foo', flags: 42}}}))
+        .be.rejectedWith('Attribute "flags" in "regexp" must be a string');
     });
 
     it('should reject filters with an invalid regular expression value', () => {
-      return should(dsl.validate({regexp: {foo: {value: 'foo(', flags: 'i'}}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({regexp: {foo: {value: 'foo(', flags: 'i'}}}))
+        .be.rejectedWith(/^Cannot parse regexp expression/);
     });
 
     it('should reject filters with invalid flags (js engine only)', () => {
@@ -50,7 +60,7 @@ describe('DSL.keyword.regexp', () => {
           }
         }
       }))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith(/^Cannot parse regexp expression/);
     });
 
     it('should validate a well-formed regular expression filter w/ flags', () => {
@@ -80,7 +90,7 @@ describe('DSL.keyword.regexp', () => {
           foo: '++'
         }
       }))
-        .be.rejectedWith(BadRequestError);
+        .be.rejectedWith(/^Cannot parse regexp expression/);
     });
   });
 

--- a/test/operands/and.test.js
+++ b/test/operands/and.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 const Koncorde = require('../../');
 
 describe('koncorde.operands.and', () => {
@@ -11,27 +10,60 @@ describe('koncorde.operands.and', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(koncorde.validate({and: []})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: []}))
+        .be.rejectedWith('Attribute "and" cannot be empty');
     });
 
     it('should reject non-array content', () => {
-      return should(koncorde.validate({and: {foo: 'bar'}})).be.rejectedWith(BadRequestError);
+      return should(koncorde.validate({and: {foo: 'bar'}}))
+        .be.rejectedWith('Attribute "and" must be an array');
     });
 
     it('should reject if one of the content is not an object', () => {
-      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, [{exists: {field: 'foo'}}]]})).be.rejectedWith(BadRequestError);
+      const filter = {
+        and: [
+          {equals: {foo: 'bar'}},
+          [ {exists: {field: 'foo'}} ],
+        ],
+      };
+
+      return should(koncorde.validate(filter))
+        .be.rejectedWith('"and" operand can only contain non-empty objects');
     });
 
     it('should reject if one of the content object does not refer to a valid keyword', () => {
-      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, {foo: 'bar'}]})).be.rejectedWith(BadRequestError);
+      const filter = {
+        and: [
+          {equals: {foo: 'bar'}},
+          {foo: 'bar'},
+        ],
+      };
+
+      return should(koncorde.validate(filter))
+        .be.rejectedWith('Unknown DSL keyword: foo');
     });
 
     it('should reject if one of the content object is not a well-formed keyword', () => {
-      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, {exists: {foo: 'bar'}}]})).be.rejectedWith(BadRequestError);
+      const filter = {
+        and: [
+          {equals: {foo: 'bar'}},
+          {exists: {foo: 'bar'}},
+        ],
+      };
+
+      return should(koncorde.validate(filter))
+        .be.rejectedWith('"exists" requires the following attribute: field');
     });
 
     it('should validate a well-formed "and" operand', () => {
-      return should(koncorde.validate({and: [{equals: {foo: 'bar'}}, {exists: {field: 'bar'}}]})).be.fulfilledWith();
+      const filter = {
+        and: [
+          {equals: {foo: 'bar'}},
+          {exists: {field: 'bar'}},
+        ],
+      };
+
+      return should(koncorde.validate(filter)).be.fulfilled();
     });
   });
 

--- a/test/operands/bool.test.js
+++ b/test/operands/bool.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 
 const DSL = require('../../');
 const NormalizedExists = require('../../lib/transform/normalizedExists');
@@ -13,11 +12,22 @@ describe('DSL.operands.bool', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({bool: {}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({bool: {}}))
+        .be.rejectedWith('"bool" must be a non-empty object');
     });
 
     it('should reject filters with unrecognized bool attributes', () => {
-      return should(dsl.validate({bool: {must: [{exists: {foo: 'bar'}}], foo: 'bar'}})).be.rejectedWith(BadRequestError);
+      const filter = {
+        bool: {
+          must: [
+            {exists: {foo: 'bar'}},
+          ],
+          foo: 'bar',
+        },
+      };
+
+      return should(dsl.validate(filter))
+        .be.rejectedWith('"bool" operand accepts only the following attributes: must, must_not, should, should_not');
     });
   });
 

--- a/test/operands/or.test.js
+++ b/test/operands/or.test.js
@@ -1,5 +1,4 @@
 const should = require('should/as-function');
-const { BadRequestError } = require('kuzzle-common-objects');
 const DSL = require('../../');
 
 describe('DSL.operands.or', () => {
@@ -11,23 +10,49 @@ describe('DSL.operands.or', () => {
 
   describe('#validation', () => {
     it('should reject empty filters', () => {
-      return should(dsl.validate({or: []})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({or: []}))
+        .be.rejectedWith('Attribute "or" cannot be empty');
     });
 
     it('should reject non-array content', () => {
-      return should(dsl.validate({or: {foo: 'bar'}})).be.rejectedWith(BadRequestError);
+      return should(dsl.validate({or: {foo: 'bar'}}))
+        .be.rejectedWith('Attribute "or" must be an array');
     });
 
     it('should reject if one of the content is not an object', () => {
-      return should(dsl.validate({or: [{equals: {foo: 'bar'}}, [{exists: {field: 'foo'}}]]})).be.rejectedWith(BadRequestError);
+      const filter = {
+        or: [
+          {equals: {foo: 'bar'}},
+          [ {exists: {field: 'foo'}} ],
+        ],
+      };
+
+      return should(dsl.validate(filter))
+        .be.rejectedWith('"or" operand can only contain non-empty objects');
     });
 
     it('should reject if one of the content object does not refer to a valid keyword', () => {
-      return should(dsl.validate({or: [{equals: {foo: 'bar'}}, {foo: 'bar'}]})).be.rejectedWith(BadRequestError);
+      const filter = {
+        or: [
+          {equals: {foo: 'bar'}},
+          {foo: 'bar'},
+        ],
+      };
+
+      return should(dsl.validate(filter))
+        .be.rejectedWith('Unknown DSL keyword: foo');
     });
 
     it('should reject if one of the content object is not a well-formed keyword', () => {
-      return should(dsl.validate({or: [{equals: {foo: 'bar'}}, {exists: {foo: 'bar'}}]})).be.rejectedWith(BadRequestError);
+      const filter = {
+        or: [
+          {equals: {foo: 'bar'}},
+          {exists: {foo: 'bar'}},
+        ],
+      };
+
+      return should(dsl.validate(filter))
+        .be.rejectedWith('"exists" requires the following attribute: field');
     });
 
     it('should validate a well-formed "or" operand', () => {


### PR DESCRIPTION
# Description

* Update all dependencies, except for `js-combinatorics` which becomes TS-only after v1.0. This one will be updated when TS interfaces are added to Koncorde
* Remove kuzzle-common-objects from dependencies
  * This means that Koncorde now throws regular Error objects instead of BadRequestError

# Other changes

* Enhanced a few error messages that were a bit confusing.
* Added a new check to the `exists` keyword (object-form) to make Koncorde throw a proper "missing field attribute" error.
* Added a proper error explanation when attempting to parse regular expressions
* Standardized `npm unit-test` to `npm test:unit` and `npm test:unit:coverage`: the former is a lot faster, useful when working on the code, while the latter includes coverage information, useful for the CI