### PR TITLE
Rename the maxMinterms configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,7 @@ constructor(options: KoncordeOptions = null)
 
 | Name | Type | Default |Description                      |
 |------|------|---------|---------------------------------|
-|`maxMinTerms`| `Number` | `256` | The maximum number of conditions a filter can hold after being canonicalized in its [CDNF](https://en.wikipedia.org/wiki/Canonical_normal_form) form. It is advised to test performances and memory consumption impacts before increasing this value. If set to 0, no limit is applied. |
+|`maxConditions`| `Number` | `50` | The maximum number of conditions a filter can hold. It is advised to test performances and memory consumption impacts before increasing this value. If set to 0, no limit is applied. |
 |`seed`|`Buffer`| fixed | 32 bytes buffer containing a fixed random seed. |
 | `regExpEngine` | `String` | `re2` | Set the engine to either [re2](https://github.com/google/re2) or [js](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp). The former is not fully compatible with PCREs, while the latter is vulnerable to [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html), making it unsafe if regular expressions are provided by end-users. |
 

--- a/lib/transform/canonical.js
+++ b/lib/transform/canonical.js
@@ -64,7 +64,9 @@ class Canonical {
     }
 
     const conditions = this._extractConditions(filters);
-    if (this.config.maxConditions && conditions.length > this.config.maxConditions) {
+    const count = this._countConditions(conditions);
+
+    if (this.config.maxConditions && count > this.config.maxConditions) {
       throw new Error('Filter too complex: exceeds the configured maximum number of conditions');
     }
 
@@ -210,6 +212,26 @@ class Canonical {
     return filters[key].reduce(
       (p, c) => this._extractConditions(c, p),
       conditions);
+  }
+
+  /**
+   * Returns the number of conditions as reworked by _extractConditions
+   *
+   * @param {Array} conditions
+   * @return {Number
+   */
+  _countConditions (conditions) {
+    let count = 0;
+
+    for (const condition of conditions) {
+      const key = Object.keys(condition)[0];
+
+      count += ['and', 'or', 'not'].includes(key)
+        ? condition[key].length
+        : 1;
+    }
+
+    return count;
   }
 
   /**

--- a/lib/transform/canonical.js
+++ b/lib/transform/canonical.js
@@ -64,8 +64,8 @@ class Canonical {
     }
 
     const conditions = this._extractConditions(filters);
-    if (this.config.maxMinTerms && conditions.length > this.config.maxMinTerms) {
-      throw new Error('Maximum number of sub conditions reached.');
+    if (this.config.maxConditions && conditions.length > this.config.maxConditions) {
+      throw new Error('Filter too complex: exceeds the configured maximum number of conditions');
     }
 
     const normalized = this._normalize(filters, conditions);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -43,6 +43,12 @@ describe('Koncorde API', () => {
       should(() => new Koncorde({ regExpEngine: 'foo' }))
         .throw({message: 'Invalid configuration value for "regExpEngine". Supported: re2, js'});
 
+      should(() => new Koncorde({ maxConditions: 'foo' }))
+        .throw({message: 'Invalid maxConditions configuration: positive or nul integer expected'});
+
+      should(() => new Koncorde({ maxConditions: -1 }))
+        .throw({message: 'Invalid maxConditions configuration: positive or nul integer expected'});
+
       {
         // valid params
         const seed = Buffer.from('01234567890123456789012345678901');

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -153,6 +153,25 @@ describe('Koncorde API', () => {
 
       should(filterIds.sort()).match(ids.sort());
     });
+
+    it('should reject if the filter is too complex', () => {
+      koncorde = new Koncorde({ maxConditions: 2 });
+
+      should(() => koncorde.register({
+        or: [
+          { equals: { foo: 'bar' } },
+          { exists: 'bar' },
+        ],
+      })).not.throw();
+
+      should(() => koncorde.register({
+        or: [
+          { equals: { foo: 'bar' } },
+          { exists: 'bar' },
+          { exists: 'foo' },
+        ],
+      })).throw('Filter too complex: exceeds the configured maximum number of conditions');
+    });
   });
 
   describe('#getFilterIds', () => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -48,13 +48,13 @@ describe('Koncorde API', () => {
         const seed = Buffer.from('01234567890123456789012345678901');
         const engine = new Koncorde({
           seed,
-          maxMinTerms: 3,
+          maxConditions: 3,
           regExpEngine: 'js',
         });
 
         should(engine.config).eql({
           seed,
-          maxMinTerms: 3,
+          maxConditions: 3,
           regExpEngine: 'js',
         });
       }


### PR DESCRIPTION
# Description

The `maxMinterms` configuration and its explanation are misleading: this limit is applied to filter's conditions, not to its minterms.
The goal of that configuration is to limit the complexity of the truth tables to build to compute the filter's DNF.

New name: `maxConditions`
