### PR TITLE
Expose the NormalizedFilter interface

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,7 +33,7 @@ import { JSONObject } from './types/JSONObject';
  * Describes a search filter normalized by Koncorde.
  * Returned by Koncorde.normalize(), and usable with Koncorde.store().
  */
-class NormalizedFilter {
+export class NormalizedFilter {
   /**
    * Normalized filter.
    *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Supersonic reverse matching engine",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
# Description

Export the `NormalizedFilter` class, allowing to rebuild a Koncorde.store argument from deserialized objects.