### PR TITLE
Fix an invalid constructor error when processing complex filters

### DIFF
--- a/lib/engine/matcher/index.js
+++ b/lib/engine/matcher/index.js
@@ -55,7 +55,9 @@ class Matcher {
     const testTables = new TestTables();
 
     for (const [ key, operand ] of foPairs) {
-      this.matchers[key](operand, testTables, data);
+      if (this.matchers[key]) {
+        this.matchers[key](operand, testTables, data);
+      }
     }
 
     return Object.keys(testTables.matched);

--- a/lib/transform/canonical.ts
+++ b/lib/transform/canonical.ts
@@ -20,12 +20,10 @@
  */
 
 import { BaseN, CartesianProduct } from 'ts-combinatorics';
-import * as EspressoImport from 'espresso-logic-minimizer';
+import { Espresso } from 'espresso-logic-minimizer';
 
 import { JSONObject } from '../types/JSONObject';
 import { strcmp } from '../util/stringCompare';
-
-const Espresso = EspressoImport.default;
 
 /**
  * Converts filters in canonical form

--- a/lib/transform/canonical.ts
+++ b/lib/transform/canonical.ts
@@ -69,7 +69,7 @@ export class Canonical {
     const count = this._countConditions(conditions);
 
     if (this.config.maxConditions && count > this.config.maxConditions) {
-      throw new Error('Filter too complex: exceeds the configured maximum number of conditions');
+      throw new Error(`Filter too complex: exceeds the configured maximum number of conditions (conditions: ${count}, max: ${this.config.maxConditions})`);
     }
 
     const normalized = this._normalize(filters, conditions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koncorde",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Supersonic reverse matching engine",
   "main": "lib/index.js",
   "directories": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -170,7 +170,7 @@ describe('Koncorde API', () => {
           { exists: 'bar' },
           { exists: 'foo' },
         ],
-      })).throw('Filter too complex: exceeds the configured maximum number of conditions');
+      })).throw(/^Filter too complex/);
     });
   });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -253,6 +253,26 @@ describe('Koncorde API', () => {
         foo: 'bar'
       })).be.true();
     });
+
+    it('should behave correctly on complex filters', () => {
+      const id = koncorde.register({
+        and: [
+          { in: { foo: ['bar', 'baz'] } },
+          {
+            or: [
+              { range: { num: { lt: 10, gte: 0 } } },
+              { range: { num: { lt: 100, gte: 90 } } },
+              { not: { range: { num: { lt: 50, gt: 40 } } } },
+            ],
+          },
+        ],
+      });
+
+      should(koncorde.test({ foo: 'qux', num: 1})).Array().and.empty();
+      should(koncorde.test({ num: 41 })).Array().and.empty();
+      should(koncorde.test({ foo: 'bar', num: 41 })).Array().and.empty();
+      should(koncorde.test({ foo: 'baz', num: 91 })).match([id]);
+    });
   });
 
   describe('#remove', () => {


### PR DESCRIPTION
# Description

Hotfixes:
- invalid import of ESPRESSO, making Koncorde fail at processing complex filters.
- the matcher was testing for the non-existent `nothing` keyword, which is a placeholder when impossible predicates are found in filter minterms

# Other changes

Better error message when a filter reaches the maximum conditions limit
