### PR TITLE
Add ability to execute a subquery on a specific index of an array

### DIFF
--- a/.eslintrc-ts.json
+++ b/.eslintrc-ts.json
@@ -11,6 +11,7 @@
   ],
   "rules": {
     "@typescript-eslint/no-explicit-any": 0,
-    "@typescript-eslint/explicit-module-boundary-types": 0
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/ban-ts-comment": 0
   }
 }

--- a/doc/terms/index.md
+++ b/doc/terms/index.md
@@ -105,6 +105,76 @@ And this filter validates the second document:
 }
 ```
 
+## select
+
+Executes a Koncorde query on a particular index of an array
+
+Negative value for the index are allowed, and will be interpreted as an offset from the end of the array, -1 being the last element.
+
+The query is executed on an object that has a single property `value` which correspond to the element in the array at the given index.
+
+### Syntax
+
+```
+select: {
+  field: <field name>,
+  index: <array index>
+  query: <koncorde query>
+}
+```
+
+### Example
+
+Given the following documents:
+
+```js
+{
+  firstName: 'Grace',
+  lastName: 'Hopper',
+  city: 'NYC',
+  hobby: ['compiler', 'COBOL'],
+  alive: false
+},
+{
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  city: 'London',
+  hobby: ['programming', 'algorithm']
+}
+```
+
+The following filter validates the first document:
+
+```js
+{
+  select: {
+    field: 'hobby',
+    index: 0,
+    query: {
+      equals: {
+        value: 'compiler'
+      }
+    }
+  }
+}
+```
+
+And this filter validates the second document:
+
+```js
+{
+  select: {
+    field: 'hobby',
+    index: -1,
+    query: {
+      equals: {
+        value: 'algorithm'
+      }
+    }
+  }
+}
+```
+
 ## match
 
 Test if properties of the filter is matching with the properties of the document.

--- a/lib/engine/matcher/index.js
+++ b/lib/engine/matcher/index.js
@@ -43,6 +43,7 @@ class Matcher {
       notregexp:  require('./matchNotRegexp'),
       range:  require('./matchRange'),
       regexp:  require('./matchRegexp'),
+      select:  require('./matchSelect').MatchSelect,
     };
   }
 

--- a/lib/engine/matcher/matchSelect.ts
+++ b/lib/engine/matcher/matchSelect.ts
@@ -31,15 +31,6 @@ import { flattenObject } from '../../util/Flatten';
  * @param {object} document
  */
 export function MatchSelect (operand, testTables, document) {
-  // const filters = operand.custom.filters;
-  // const subfilters = filters
-  //   .filter(filterInfo => matchAny(document, filterInfo.value))
-  //   .map(filterInfo => filterInfo.subfilter);
-
-  // if (subfilters.length > 0) {
-  //   testTables.addMatch(subfilters);
-  // }
-
   for (const [key, indexMap] of operand.fields.entries()) {
     if (!Array.isArray(document[key])) {
       continue;

--- a/lib/engine/matcher/matchSelect.ts
+++ b/lib/engine/matcher/matchSelect.ts
@@ -1,0 +1,65 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2021 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { flattenObject } from '../../util/Flatten';
+
+
+/**
+ * Updates the matched filters according to the provided data
+ * O(n) with n the number of values to be tested against document fields
+ *
+ * @param {FieldOperand} operand - content of all conditions to be tested
+ * @param {object} testTables - test tables to update when a filter matches the document
+ * @param {object} document
+ */
+export function MatchSelect (operand, testTables, document) {
+  // const filters = operand.custom.filters;
+  // const subfilters = filters
+  //   .filter(filterInfo => matchAny(document, filterInfo.value))
+  //   .map(filterInfo => filterInfo.subfilter);
+
+  // if (subfilters.length > 0) {
+  //   testTables.addMatch(subfilters);
+  // }
+
+  for (const [key, indexMap] of operand.fields.entries()) {
+    if (!Array.isArray(document[key])) {
+      continue;
+    }
+
+    for (const [index, indexEngine] of indexMap.entries()) {
+      // If the index is negative, we need to count from the end of the array
+      const computedIndex = index >= 0 ? index : document[key].length + index;
+
+      if (computedIndex < 0 || computedIndex >= document[key].length) {
+        continue;
+      }
+      
+      const value = document[key][computedIndex];
+
+      const matchedFilters = indexEngine.engine.match(flattenObject({ value }));
+
+      for (const filterId of matchedFilters) {
+        testTables.addMatch(indexEngine.filters.get(filterId));
+      }
+    }
+  }
+}

--- a/lib/engine/removeOperands.js
+++ b/lib/engine/removeOperands.js
@@ -104,6 +104,53 @@ class OperandsRemoval {
   }
 
   /**
+   * Removes a "select" value from the field-operand structure
+   *
+   * The condition
+   * @param {CacheStorage} foPairs
+   * @param {object} subfilter
+   * @param {object} condition
+   */
+  select(foPairs, subfilter, condition) {
+    const fieldName = condition.value.field;
+    const index = condition.value.index;
+
+    const operand = foPairs.get('select');
+    const field = operand.fields.get(fieldName);
+    const indexEngine = field.get(index);
+
+    if (indexEngine) {
+      for (const [filterId, filters] of indexEngine.filters) {
+        const subfilterIndex = filters.findIndex((f) => f.id === subfilter.id);
+
+        if (subfilterIndex !== -1) {
+          filters.splice(subfilterIndex, 1);
+
+          
+          if (filters.length === 0) {
+            indexEngine.filters.delete(filterId);
+            indexEngine.engine.remove(filterId);
+          }
+
+          break;
+        }
+      }
+
+      if (indexEngine.filters.size === 0) {
+        field.delete(index);
+      }
+
+      if (field.size === 0) {
+        operand.fields.delete(fieldName);
+      }
+
+      if (operand.fields.size === 0) {
+        foPairs.delete('select');
+      }
+    }
+  }
+
+  /**
    * Removes a "match" value from the field-operand structure
    *
    * The condition

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,6 +27,7 @@ import { convertDistance } from './util/convertDistance';
 import { convertGeopoint } from './util/convertGeopoint';
 import { hash } from './util/hash';
 import { JSONObject } from './types/JSONObject';
+import { flattenObject } from './util/Flatten';
 
 
 /**
@@ -311,48 +312,4 @@ export class Koncorde {
   }
 }
 
-/**
- * Flatten an object transform:
- * {
- *  title: "kuzzle",
- *  info : {
- *    tag: "news"
- *  }
- * }
- *
- * Into an object like:
- * {
- *  title: "kuzzle",
- *  info.tag: news
- * }
- *
- * @param {Object} target the object we have to flatten
- * @returns {Object} the flattened object
- */
-function flattenObject(target: JSONObject): JSONObject {
-  const output = {};
 
-  flattenStep(output, target);
-
-  return output;
-}
-
-function flattenStep(
-  output: JSONObject,
-  object: JSONObject,
-  prev: string = null): void {
-  const keys = Object.keys(object);
-
-  for(let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    const value = object[key];
-    const newKey = prev ? prev + '.' + key : key;
-
-    if (Object.prototype.toString.call(value) === '[object Object]') {
-      output[newKey] = value;
-      flattenStep(output, value, newKey);
-    }
-
-    output[newKey] = value;
-  }
-}

--- a/lib/transform/standardize.js
+++ b/lib/transform/standardize.js
@@ -57,8 +57,9 @@ class Standardizer {
       'not',
       'nothing',
       'or',
+      'select',
       'range',
-      'regexp'
+      'regexp',
     ]);
   }
 
@@ -325,6 +326,26 @@ class Standardizer {
     const field = Object.keys(filter.equals)[0];
     isScalar(filter.equals, field, 'equals', pathAdd(path, field));
 
+    return filter;
+  }
+
+  /**
+     * Validate a "select" keyword
+     *
+     * @param {Object} filter
+     * @param {String} path - currently examined filter path
+     * @returns {Object} standardized filter
+     */
+  select(filter, path) {
+    isObject(filter, 'select', 'select', path, { properties: 3 });
+  
+    isString(filter.select, 'field', 'select', pathAdd(path, 'field'));
+    isInteger(filter.select, 'index', 'select', pathAdd(path, 'index'));
+    isObject(filter.select, 'query', 'select', pathAdd(path, 'query'), { nonEmpty: true });
+      
+  
+    this.standardize(filter.select.query, pathAdd(path, 'query'));
+      
     return filter;
   }
 
@@ -863,6 +884,25 @@ function isString(filter, property, keyword, path) {
 
   if (filter[property].length === 0) {
     throw new KoncordeParseError('cannot be empty', keyword, path);
+  }
+}
+
+/**
+ * Verifies that "filter.property" is an integer
+ *
+ * @param {Object} filter
+ * @param {String} property to examine
+ * @param {String} keyword - currently examined keyword
+ * @param {String} path - currently examined filter path
+ */
+function isInteger(filter, property, keyword, path) {
+  if (typeof filter[property] !== 'number') {
+    throw new KoncordeParseError('must be an integer', keyword, path);
+  }
+
+
+  if (Math.floor(filter[property]) !== filter[property]) {
+    throw new KoncordeParseError('cannot have decimals, must be an integer', keyword, path);
   }
 }
 

--- a/lib/util/Flatten.ts
+++ b/lib/util/Flatten.ts
@@ -1,0 +1,47 @@
+import { JSONObject } from '../types/JSONObject';
+
+/**
+ * Flatten an object transform:
+ * {
+ *  title: "kuzzle",
+ *  info : {
+ *    tag: "news"
+ *  }
+ * }
+ *
+ * Into an object like:
+ * {
+ *  title: "kuzzle",
+ *  info.tag: news
+ * }
+ *
+ * @param {Object} target the object we have to flatten
+ * @returns {Object} the flattened object
+ */
+export function flattenObject(target: JSONObject): JSONObject {
+  const output = {};
+
+  flattenStep(output, target);
+
+  return output;
+}
+
+function flattenStep(
+  output: JSONObject,
+  object: JSONObject,
+  prev: string = null): void {
+  const keys = Object.keys(object);
+
+  for(let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = object[key];
+    const newKey = prev ? prev + '.' + key : key;
+
+    if (Object.prototype.toString.call(value) === '[object Object]') {
+      output[newKey] = value;
+      flattenStep(output, value, newKey);
+    }
+
+    output[newKey] = value;
+  }
+}

--- a/test/keywords/select.test.js
+++ b/test/keywords/select.test.js
@@ -1,0 +1,469 @@
+const should = require('should/as-function');
+
+const FieldOperand = require('../../lib/engine/objects/fieldOperand');
+const { Koncorde } = require('../../');
+
+describe('Koncorde.keyword.select', () => {
+  let koncorde;
+  let engine;
+
+  beforeEach(() => {
+    koncorde = new Koncorde();
+    engine = koncorde.engines.get(null);
+  });
+
+  function getSubfilter(id) {
+    return Array.from(engine.filters.get(id).subfilters)[0];
+  }
+
+  describe('#validation', () => {
+    it('should reject non-object filters', () => {
+      should(() => koncorde.validate({select: ['foo', 'bar']}))
+        .throw({
+          keyword: 'select',
+          message: '"select": must be an object',
+          path: 'select',
+        });
+    });
+
+    it('should reject empty filters', () => {
+      should(() => koncorde.validate({select: {}}))
+        .throw({
+          keyword: 'select',
+          message: '"select": expected object to have exactly 3 properties, got 0',
+          path: 'select',
+        });
+    });
+
+    it('should reject filters with missing field "field"', () => {
+      should(() => koncorde.validate({select: {
+        foo: 'bar',
+        index: 0,
+        query: {
+          equals: {value: 'bar'}
+        }
+      }}))
+        .throw({
+          keyword: 'select',
+          message: '"select.field": must be a string',
+          path: 'select.field',
+        });
+    });
+
+    it('should reject filters with missing field "index"', () => {
+      should(() => koncorde.validate({select: {
+        foo: 'bar',
+        field: 'foo',
+        query: {
+          equals: {value: 'bar'}
+        }
+      }}))
+        .throw({
+          keyword: 'select',
+          message: '"select.index": must be an integer',
+          path: 'select.index',
+        });
+    });
+
+    it('should reject filters with missing field "query"', () => {
+      should(() => koncorde.validate({select: {
+        foo: 'bar',
+        field: 'foo',
+        index: 0,
+      }}))
+        .throw({
+          keyword: 'select',
+          message: '"select.query": must be an object',
+          path: 'select.query',
+        });
+    });
+
+    it('should reject filters when field is not a string', () => {
+      should(() => koncorde.validate({select: {
+        field: 42,
+        index: 0,
+        query: {
+          equals: {value: 'bar'}
+        }
+      }}))
+        .throw({
+          keyword: 'select',
+          message: '"select.field": must be a string',
+          path: 'select.field',
+        });
+    });
+
+    it('should reject filters when index is not an integer', () => {
+      should(() => koncorde.validate({select: {
+        field: 'foo',
+        index: 1.2,
+        query: {
+          equals: {value: 'bar'}
+        }
+      }}))
+        .throw({
+          keyword: 'select',
+          message: '"select.index": cannot have decimals, must be an integer',
+          path: 'select.index',
+        });
+    });
+
+    it('should reject filters when query is not a valid Koncorde query', () => {
+      should(() => koncorde.validate({select: {
+        field: 'foo',
+        index: 0,
+        query: {
+          yeet: {foo: 'bar'}
+        }
+      }}))
+        .throw({
+          keyword: 'yeet',
+          message: '"select.query.yeet": unknown keyword',
+          path: 'select.query.yeet',
+        });
+    });
+  });
+
+  describe('#standardization', () => {
+    it('should return the same content, unchanged', () => {
+      should(koncorde.transformer.standardizer.standardize({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      }))
+        .match({
+          select: {
+            field: 'foo',
+            index: 0,
+            query: {
+              equals: { value: 'bar' }
+            }
+          }
+        });
+    });
+  });
+
+  describe('#storage', () => {
+    it('should store a single condition correctly', () => {
+      const id = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      
+      const storage = engine.foPairs.get('select');
+      const subfilter = getSubfilter(id);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(0).filters.size).equal(1);
+      const subfilters = Array.from(storage.fields.get('foo').get(0).filters.values()).flat();
+      should(subfilters.findIndex(f => f.id === subfilter.id)).not.equal(-1);
+    });
+
+    it('should store multiple conditions on the same field correctly', () => {
+      const id1 = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      const id2 = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'qux' }
+          }
+        }
+      });
+
+      const barSubfilter = getSubfilter(id1);
+      const quxSubfilter = getSubfilter(id2);
+      const storage = engine.foPairs.get('select');
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(0).filters.size).equal(2);
+      const subfilters = Array.from(storage.fields.get('foo').get(0).filters.values()).flat();
+      should(subfilters.findIndex(f => f.id === barSubfilter.id)).not.equal(-1);
+      should(subfilters.findIndex(f => f.id === quxSubfilter.id)).not.equal(-1);
+    });
+
+    it('should store multiple subfilters on the same condition correctly', () => {
+      const id1 = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      
+      const id2 = koncorde.register({
+        and: [
+          {
+            select: {
+              field: 'baz',
+              index: 0,
+              query: {
+                equals: { value: 'qux' }
+              }
+            }
+          },
+          {
+            select: {
+              field: 'foo',
+              index: 0,
+              query: {
+                equals: { value: 'bar' }
+              }
+            }
+          }
+        ]
+      });
+
+      const barSubfilter = getSubfilter(id1);
+      const multiSubfilter = getSubfilter(id2);
+      const storage = engine.foPairs.get('select');
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('baz'))
+        .instanceOf(Map);
+      should(storage.fields.get('baz').get(0).filters.size).equal(1);
+      let subfilters = Array.from(storage.fields.get('baz').get(0).filters.values()).flat();
+      should(subfilters.findIndex(f => f.id === multiSubfilter.id)).not.equal(-1);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(0).filters.size).equal(1);
+      subfilters = Array.from(storage.fields.get('foo').get(0).filters.values()).flat();
+      should(subfilters.length).equal(2);
+      should(subfilters.findIndex(f => f.id === barSubfilter.id)).not.equal(-1);
+      should(subfilters.findIndex(f => f.id === multiSubfilter.id)).not.equal(-1);
+      
+    });
+  });
+
+  describe('#matching', () => {
+    it('should match a document with the subscribed keyword', () => {
+      const id = koncorde.register({
+        select: {
+          field: 'foo',
+          index: -1,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      const result = koncorde.test({foo: ['qux', 'bar']});
+
+      should(result).be.an.Array().and.not.empty();
+      should(result[0]).be.eql(id);
+    });
+
+    it('should not match if the document contains the field with another value', () => {
+      koncorde.register({
+        select: {
+          field: 'foo',
+          index: -1,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+
+      should(koncorde.test({foo: ['bar', 'qux']})).be.an.Array().and.be.empty();
+    });
+
+    it('should not match if the document contains another field with the registered value', () => {
+      koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      should(koncorde.test({ qux: ['bar'] })).be.an.Array().and.be.empty();
+    });
+
+    // see https://github.com/kuzzleio/koncorde/issues/13
+    it('should skip the matching if the document tested property is not of the same type than the known values', () => {
+      koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+
+      should(koncorde.test({ foo: 'bar' })).be.an.Array().and.empty();
+
+      should(koncorde.test({ foo: { bar: true } })).be.an.Array().and.empty();
+    });
+
+    it('should match a document with the subscribed nested keyword', () => {
+      const id = koncorde.register({
+        select: {
+          field: 'foo.bar.baz',
+          index: 0,
+          query: {
+            equals: { value: 'qux' }
+          }
+        }
+      });
+      const result = koncorde.test({ foo: { bar: { baz: ['qux'] } } });
+
+      should(result).be.an.Array().and.not.empty();
+      should(result[0]).be.eql(id);
+    });
+  });
+
+  describe('#removal', () => {
+    it('should destroy the whole structure when removing the last item', () => {
+      const id = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+
+      koncorde.remove(id);
+
+      should(engine.foPairs).be.an.Object().and.be.empty();
+    });
+
+    it('should remove a single subfilter from a multi-filter condition', () => {
+      const id1 = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      const id2 = koncorde.register({
+        and: [
+          {
+            select: {
+              field: 'baz',
+              index: 0,
+              query: {
+                equals: { value: 'qux' }
+              }
+            }
+          },
+          {
+            select: {
+              field: 'foo',
+              index: 0,
+              query: {
+                equals: { value: 'bar' }
+              }
+            }
+          },
+        ],
+      });
+
+      koncorde.remove(id1);
+
+      const storage = engine.foPairs.get('select');
+      const multiSubfilter = getSubfilter(id2);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('baz'))
+        .instanceOf(Map);
+      should(storage.fields.get('baz').get(0).filters.size).equal(1);
+      let subfilters = Array.from(storage.fields.get('baz').get(0).filters.values()).flat();
+      should(subfilters.length).equal(1);
+      should(subfilters.findIndex(f => f.id === multiSubfilter.id)).not.equal(-1);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(0).filters.size).equal(1);
+      subfilters = Array.from(storage.fields.get('foo').get(0).filters.values()).flat();
+      should(subfilters.length).equal(1);
+      should(subfilters.findIndex(f => f.id === multiSubfilter.id)).not.equal(-1);
+    });
+
+    it('should remove a value from the list if its last subfilter is removed', () => {
+      const id1 = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 0,
+          query: {
+            equals: { value: 'bar' }
+          }
+        }
+      });
+      const id2 = koncorde.register({
+        select: {
+          field: 'foo',
+          index: 1,
+          query: {
+            equals: { value: 'qux' }
+          }
+        }
+      });
+
+      const storage = engine.foPairs.get('select');
+      const barSubfilter = getSubfilter(id1);
+      const quxSubfilter = getSubfilter(id2);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(0).filters.size).equal(1);
+      let subfilters = Array.from(storage.fields.get('foo').get(0).filters.values()).flat();
+      should(subfilters.length).equal(1);
+      should(subfilters.findIndex(f => f.id === barSubfilter.id)).not.equal(-1);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(1).filters.size).equal(1);
+      subfilters = Array.from(storage.fields.get('foo').get(1).filters.values()).flat();
+      should(subfilters.length).equal(1);
+      should(subfilters.findIndex(f => f.id === quxSubfilter.id)).not.equal(-1);
+
+      koncorde.remove(id2);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(0).filters.size).equal(1);
+      subfilters = Array.from(storage.fields.get('foo').get(0).filters.values()).flat();
+      should(subfilters.length).equal(1);
+      should(subfilters.findIndex(f => f.id === barSubfilter.id)).not.equal(-1);
+
+      should(storage).be.instanceOf(FieldOperand);
+      should(storage.fields.get('foo'))
+        .instanceOf(Map);
+      should(storage.fields.get('foo').get(1)).be.undefined();
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do ?

Add a new keyword `select` that allows execute a subquery on a specific index of an array.

**select**

Executes a Koncorde query on a particular index of an array

Negative value for the index are allowed, and will be interpreted as an offset from the end of the array, -1 being the last element.

The query is executed on an object that has a single property `value` which correspond to the element in the array at the given index.

```
select: {
  field: <field name>,
  index: <array index>
  query: <koncorde query>
}
```