### PR TITLE
fix: id generation algorithm for complex filters

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -129,11 +129,17 @@ describe('Koncorde API', () => {
 
     it('should resolve to the different id for equivalent filters and different values', () => {
       const id1 = koncorde.register({
-        and : [ { equals: { city: 'Montpellier' } }, { equals: {city: 'Nimes'} } ]
+        and : [ 
+          { equals: { city: 'Montpellier' } }, 
+          { equals: {city: 'Nimes'} } 
+        ]
       });
 
       const id2 = koncorde.register({
-        and : [ { equals: { city: 'Montpellier' } }, { equals: {city: 'Test'} } ]
+        and : [ 
+          { equals: { city: 'Montpellier' } }, 
+          { equals: {city: 'Test'} } 
+        ]
       });
 
       should(id1).not.eql(id2);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -127,6 +127,18 @@ describe('Koncorde API', () => {
       should(id1).eql(id3);
     });
 
+    it('should resolve to the different id for equivalent filters and different values', () => {
+      const id1 = koncorde.register({
+        and : [ { equals: { city: 'Montpellier' } }, { equals: {city: 'Nimes'} } ]
+      });
+
+      const id2 = koncorde.register({
+        and : [ { equals: { city: 'Montpellier' } }, { equals: {city: 'Test'} } ]
+      });
+
+      should(id1).not.eql(id2);
+    });
+
     it('should not recreate an already existing subfilter', () => {
       const ids = [];
 


### PR DESCRIPTION
<!--
  This template is not mandatory.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
<!-- Please fulfill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

The filter ID generation algorithm is potentially flawed, complex filters like
```json
{
        "and" : [ 
          { "equals": { "city": "Montpellier" } }, 
          { "equals": { "city": "Nimes"} } 
        ]
}
```
and
```json
{
        "and" : [ 
          { "equals": { "city": "Montpellier"} }, 
          { "equals": { "city": "Lyon"} } 
        ]
}
```
will inherently get the same ID although they are different.

This PR isn't done and only represent the current issue Koncorde filters ID have.
